### PR TITLE
Updated to latest healthcheck, fixed code, test and example accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ For graceful handling of Closing consumers, it is advised to use the `StopListen
 
 ## Health-check
 
-The health status of a consumer or producer can be obtained by calling `Checker` method, which returns a Check structure with the information:
+The health status of a consumer or producer can be obtained by calling `Checker` method, which updates the provided CheckState structure with the relevant information:
 ```
 check, err = cli.Checker(ctx)
 ```
 
-- If a broker cannot be reached, a CRITICAL check is returned. 
-- If all brokers can be reached, but a broker does not provide the expected topic metadata, a WARNING check is returned.
-- If all brokers can be reached and return the expected topic metadata, we try to initialise the consumer/producer. If it was already initialised, or the initialisation is successful, an OK check is returned.
+- If a broker cannot be reached, the Status is set to CRITICAL. 
+- If all brokers can be reached, but a broker does not provide the expected topic metadata, the Status is set to WARNING.
+- If all brokers can be reached and return the expected topic metadata, we try to initialise the consumer/producer. If it was already initialised, or the initialisation is successful, the Status is set to OK.
 
 ## Example
 

--- a/consumer-group.go
+++ b/consumer-group.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"
 	cluster "github.com/bsm/sarama-cluster"
 )
@@ -20,7 +19,6 @@ type ConsumerGroup struct {
 	topic     string
 	group     string
 	sync      bool
-	Check     *health.Check
 	config    *cluster.Config
 	cli       SaramaCluster
 	mutexInit *sync.Mutex
@@ -67,10 +65,6 @@ func NewConsumerWithClusterClient(
 		cli:       cli,
 		mutexInit: &sync.Mutex{},
 	}
-
-	// Initial check structure
-	check := &health.Check{Name: ServiceName}
-	cg.Check = check
 
 	// Validate provided channels and assign them to consumer group. ErrNoChannel should be considered fatal by caller.
 	err = channels.Validate()

--- a/consumer-group_test.go
+++ b/consumer-group_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka"
 	"github.com/ONSdigital/dp-kafka/mock"
 	"github.com/Shopify/sarama"
@@ -103,12 +102,10 @@ func TestConsumer(t *testing.T) {
 		channels := kafka.CreateConsumerGroupChannels(true)
 		consumer, err := kafka.NewConsumerWithClusterClient(
 			ctx, testBrokers, testTopic, testGroup, kafka.OffsetNewest, true, channels, clusterCli)
-		expectedCheck := health.Check{Name: kafka.ServiceName}
 
 		Convey("Consumer is correctly created and initialised without error", func() {
 			So(err, ShouldBeNil)
 			So(consumer, ShouldNotBeNil)
-			So(consumer.Check, ShouldResemble, &expectedCheck)
 			So(channels.Upstream, ShouldEqual, channels.Upstream)
 			So(channels.Errors, ShouldEqual, channels.Errors)
 			So(len(clusterCli.NewConsumerCalls()), ShouldEqual, 1)
@@ -160,12 +157,10 @@ func TestConsumerNotInitialised(t *testing.T) {
 		channels := kafka.CreateConsumerGroupChannels(true)
 		consumer, err := kafka.NewConsumerWithClusterClient(
 			ctx, testBrokers, testTopic, testGroup, kafka.OffsetNewest, true, channels, clusterCli)
-		expectedCheck := health.Check{Name: kafka.ServiceName}
 
 		Convey("Consumer is partially created with channels and checker, returning the Sarama error, and is not initialised", func() {
 			So(err, ShouldEqual, ErrSaramaNoBrokers)
 			So(consumer, ShouldNotBeNil)
-			So(consumer.Check, ShouldResemble, &expectedCheck)
 			So(channels.Upstream, ShouldEqual, channels.Upstream)
 			So(channels.Errors, ShouldEqual, channels.Errors)
 			So(len(clusterCli.NewConsumerCalls()), ShouldEqual, 1)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-kafka
 go 1.12
 
 require (
-	github.com/ONSdigital/dp-healthcheck v0.0.0-20200115183048-4eeccfeaf78a
+	github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e
 	github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20
 	github.com/Shopify/sarama v1.24.1
 	github.com/bsm/sarama-cluster v2.1.15+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200115183048-4eeccfeaf78a h1:8VMB6ABLt8dNSM6iFPy+QrJigirl9Dafv/CvyNbu9Ps=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200115183048-4eeccfeaf78a/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
+github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59 h1:B4IEjh0R3/WYT2INXfMt/4gUtk8SSaMKaojbCMGkBHo=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"context"
 	"errors"
-	"time"
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"
@@ -19,38 +18,26 @@ const MsgHealthyProducer = "kafka producer is healthy"
 // MsgHealthyConsumerGroup Check message returned when Kafka consumer group is healthy.
 const MsgHealthyConsumerGroup = "kafka consumer group is healthy"
 
-// Checker checks health of Kafka producer and returns it inside its Check structure.
-func (p *Producer) Checker(ctx context.Context) (*health.Check, error) {
+// Checker checks health of Kafka producer and updates the provided CheckState accordingly
+func (p *Producer) Checker(ctx context.Context, state *health.CheckState) error {
 	err := p.healthcheck(ctx)
-	currentTime := time.Now().UTC()
-	p.Check.LastChecked = &currentTime
 	if err != nil {
-		p.Check.LastFailure = &currentTime
-		p.Check.Status = getStatusFromError(err)
-		p.Check.Message = err.Error()
-		return p.Check, err
+		state.Update(getStatusFromError(err), err.Error(), 0)
+		return nil
 	}
-	p.Check.LastSuccess = &currentTime
-	p.Check.Status = health.StatusOK
-	p.Check.Message = MsgHealthyProducer
-	return p.Check, nil
+	state.Update(health.StatusOK, MsgHealthyProducer, 0)
+	return nil
 }
 
-// Checker checks health of Kafka consumer-group and returns it inside its Check structure.
-func (cg *ConsumerGroup) Checker(ctx context.Context) (*health.Check, error) {
+// Checker checks health of Kafka consumer-group and updates the provided CheckState accordingly
+func (cg *ConsumerGroup) Checker(ctx context.Context, state *health.CheckState) error {
 	err := cg.healthcheck(ctx)
-	currentTime := time.Now().UTC()
-	cg.Check.LastChecked = &currentTime
 	if err != nil {
-		cg.Check.LastFailure = &currentTime
-		cg.Check.Status = getStatusFromError(err)
-		cg.Check.Message = err.Error()
-		return cg.Check, err
+		state.Update(getStatusFromError(err), err.Error(), 0)
+		return nil
 	}
-	cg.Check.LastSuccess = &currentTime
-	cg.Check.Status = health.StatusOK
-	cg.Check.Message = MsgHealthyConsumerGroup
-	return cg.Check, nil
+	state.Update(health.StatusOK, MsgHealthyConsumerGroup, 0)
+	return nil
 }
 
 // getStatusFromError decides the health status (severity) according to the provided error

--- a/producer.go
+++ b/producer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/Shopify/sarama"
 )
@@ -16,7 +15,6 @@ type Producer struct {
 	brokers   []string
 	topic     string
 	channels  *ProducerChannels
-	Check     *health.Check
 	cli       Sarama
 	mutexInit *sync.Mutex
 }
@@ -47,10 +45,6 @@ func NewProducerWithSaramaClient(
 		cli:       cli,
 		mutexInit: &sync.Mutex{},
 	}
-
-	// Initial Check struct
-	check := &health.Check{Name: ServiceName}
-	producer.Check = check
 
 	// Validate provided channels and assign them to producer. ErrNoChannel should be considered fatal by caller.
 	err = channels.Validate()

--- a/producer_test.go
+++ b/producer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka"
 	"github.com/ONSdigital/dp-kafka/kafkatest"
 	"github.com/ONSdigital/dp-kafka/mock"
@@ -131,12 +130,9 @@ func TestProducer(t *testing.T) {
 		producer, err := kafka.NewProducerWithSaramaClient(
 			ctx, testBrokers, testTopic, 123, channels, saramaCli)
 
-		expectedCheck := health.Check{Name: kafka.ServiceName}
-
 		Convey("Producer is correctly created and initialised without error", func() {
 			So(err, ShouldBeNil)
 			So(producer, ShouldNotBeNil)
-			So(producer.Check, ShouldResemble, &expectedCheck)
 			So(channels.Output, ShouldEqual, channels.Output)
 			So(channels.Errors, ShouldEqual, channels.Errors)
 			So(len(saramaCli.NewAsyncProducerCalls()), ShouldEqual, 1)
@@ -234,12 +230,9 @@ func TestProducerNotInitialised(t *testing.T) {
 		producer, err := kafka.NewProducerWithSaramaClient(
 			ctx, testBrokers, testTopic, 123, channels, saramaCliWithErr)
 
-		expectedCheck := health.Check{Name: kafka.ServiceName}
-
 		Convey("Producer is partially created with channels and checker, returning the Sarama error and not initialised", func() {
 			So(err, ShouldEqual, ErrSaramaNoBrokers)
 			So(producer, ShouldNotBeNil)
-			So(producer.Check, ShouldResemble, &expectedCheck)
 			So(channels.Output, ShouldEqual, channels.Output)
 			So(channels.Errors, ShouldEqual, channels.Errors)
 			So(len(saramaCliWithErr.NewAsyncProducerCalls()), ShouldEqual, 1)


### PR DESCRIPTION
### What

- updated to the newest version of the health-check library
- removed Check object from Client (as now they are all centralised in the health-check library)
- adapted the tests to new behaviour
- adapted the example to new behaviour, with a real health-check instance.

### How to review

- Check that the code changes make sense
- Tests should pass
- You can try that the example still works by doing `go run main.go` in cmd/kafka-example.

### Who can review

Anyone.
