### PR TITLE
Fix close race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Producers can be closed calling the `Close` method.
 
 For graceful handling of Closing consumers, it is advised to use the `StopListeningToConsumer` method prior to the `Close` method. This will allow inflight messages to be completed and successfully call commit so that the message does not get replayed once the application restarts.
 
+After successfully closing a producer or consumer, the corresponding `Closed` channel is closed.
+
 ## Health-check
 
 The health status of a consumer or producer can be obtained by calling `Checker` method, which updates the provided CheckState structure with the relevant information:

--- a/consumer-group_test.go
+++ b/consumer-group_test.go
@@ -121,14 +121,14 @@ func TestConsumer(t *testing.T) {
 			So(len(clusterConsumerMock.CloseCalls()), ShouldEqual, 0)
 		})
 
-		Convey("StopListeningToConsumer closes closer and closed channels, without actually closing sarama-cluster consumer", func() {
+		Convey("StopListeningToConsumer closes closer channels, without actually closing sarama-cluster consumer", func() {
 			consumer.StopListeningToConsumer(ctx)
 			validateChannelClosed(channels.Closer, true)
-			validateChannelClosed(channels.Closed, true)
+			validateChannelClosed(channels.Closed, false)
 			So(len(clusterConsumerMock.CloseCalls()), ShouldEqual, 0)
 		})
 
-		Convey("Closing the consumer closes Sarama-cluster consumer", func() {
+		Convey("Closing the consumer closes Sarama-cluster consumer and closed channel", func() {
 			consumer.Close(ctx)
 			validateChannelClosed(channels.Closer, true)
 			validateChannelClosed(channels.Closed, true)
@@ -173,10 +173,10 @@ func TestConsumerNotInitialised(t *testing.T) {
 			So(len(clusterCli.NewConsumerCalls()), ShouldEqual, 2)
 		})
 
-		Convey("StopListeningToConsumer closes closer and closed channels", func() {
+		Convey("StopListeningToConsumer closes closer channel only", func() {
 			consumer.StopListeningToConsumer(ctx)
 			validateChannelClosed(channels.Closer, true)
-			validateChannelClosed(channels.Closed, true)
+			validateChannelClosed(channels.Closed, false)
 		})
 
 		Convey("Closing the consumer closes the caller channels", func() {


### PR DESCRIPTION
### What

- Replaced `Closed` channel usage with wgClose (waitgroup), so that the main thread will wait for all the go-routines to finish, instead of waiting for the `Closed` channel to be closed (before this PR, any go-routine could close it)
- Repurposed `Closed` channel to be closed once the Sarama producer/consumer has been successfully closed, so that the caller can act upon this event.
- This race condition only existed in the consumer (not in the producer, as we only have a single go-routine), but for consistency, I applied the same changes in both.

### How to review

- Make sure the changes make sense
- Unit tests should pass
- I tried the changes in dp-import-tracker several times and didn't see the race-condition again (it used to happen randomly during shutdown)

### Who can review

Anyone.