### PR TITLE
Expose Checker methods for producer and consumer-group interfaces

### DIFF
--- a/consumer-group.go
+++ b/consumer-group.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
@@ -23,6 +24,7 @@ type IConsumerGroup interface {
 	Release()
 	CommitAndRelease(msg Message)
 	StopListeningToConsumer(ctx context.Context) (err error)
+	Checker(ctx context.Context, state *health.CheckState) error
 	Close(ctx context.Context) (err error)
 }
 

--- a/producer.go
+++ b/producer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/Shopify/sarama"
 	"github.com/rcrowley/go-metrics"
@@ -16,6 +17,7 @@ type IProducer interface {
 	Channels() *ProducerChannels
 	IsInitialised() bool
 	Initialise(ctx context.Context) error
+	Checker(ctx context.Context, state *health.CheckState) error
 	Close(ctx context.Context) (err error)
 }
 


### PR DESCRIPTION
### What

- Expose `Checker` methods in producer and consumer-group interfaces
- Re-generated mocks accordingly
The reason is that any service that requires to use these mocks for 'service lifecycle' unit-testing (i.e. client creation, register checkers and graceful shutdown) would need those methods.

### How to review

- Make sure changes make sense
- Unit tests should pass

### Who can review

Anyone