### PR TITLE
message mock closes the upstreamDone channel,

### DIFF
--- a/kafkatest/message.go
+++ b/kafkatest/message.go
@@ -53,6 +53,7 @@ func (internal *mInternal) commitFunc() {
 	internal.mu.Lock()
 	defer internal.mu.Unlock()
 	internal.committed = true
+	close(internal.upstreamDoneChan)
 }
 
 // committedFunc returns true if commit was called on this message.


### PR DESCRIPTION
### What

Bug fix:

The message mock (kafkatest) didn't release the upstreamDone channel. In this task, the channel is closed when commit() is called, to emulate the behaviour of a real message. 

### How to review

- Make sure code change makes sense
- Unit tests should pass

- Already validated with `dp-dimension extractor` (a test was failing for this reason before)

### Who can review

Anyone