### PR TITLE
Extended message to expose Mark, Commit, Release and CommitAndRelease

### DIFF
--- a/consumer_group_handler_test.go
+++ b/consumer_group_handler_test.go
@@ -155,7 +155,7 @@ func consume(c C, ch chan Message) int {
 			if !ok {
 				return numConsum
 			}
-			msg.Commit()
+			msg.CommitAndRelease()
 			validateChannelClosed(c, msg.UpstreamDone(), true)
 			numConsum++
 		case <-time.After(TIMEOUT):

--- a/examples/consumer-concurrent/main.go
+++ b/examples/consumer-concurrent/main.go
@@ -138,8 +138,8 @@ func consume(ctx context.Context, cfg *Config, id int, upstream chan kafka.Messa
 		// Allows us to dictate the process for shutting down and how fast we consume messages in this example app, (should not be used in applications)
 		sleepIfRequired(ctx, cfg, logData)
 
-		consumedMessage.Commit()
-		log.Event(ctx, "[KAFKA-TEST] committed message", log.INFO, logData)
+		consumedMessage.CommitAndRelease()
+		log.Event(ctx, "[KAFKA-TEST] committed and released message", log.INFO, logData)
 	}
 }
 

--- a/examples/consumer-sequential/main.go
+++ b/examples/consumer-sequential/main.go
@@ -124,8 +124,8 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 				// Allows us to dictate the process for shutting down and how fast we consume messages in this example app, (should not be used in applications)
 				sleepIfRequired(ctx, cfg, logData)
 
-				consumedMessage.Commit()
-				log.Event(ctx, "[KAFKA-TEST] committed message", log.INFO, log.Data{"messageOffset": consumedMessage.Offset()})
+				consumedMessage.CommitAndRelease()
+				log.Event(ctx, "[KAFKA-TEST] committed and released message", log.INFO, log.Data{"messageOffset": consumedMessage.Offset()})
 			}
 		}
 	}()

--- a/kafkatest/mock_message.go
+++ b/kafkatest/mock_message.go
@@ -9,10 +9,13 @@ import (
 )
 
 var (
-	lockMessageMockCommit       sync.RWMutex
-	lockMessageMockGetData      sync.RWMutex
-	lockMessageMockOffset       sync.RWMutex
-	lockMessageMockUpstreamDone sync.RWMutex
+	lockMessageMockCommit           sync.RWMutex
+	lockMessageMockCommitAndRelease sync.RWMutex
+	lockMessageMockGetData          sync.RWMutex
+	lockMessageMockMark             sync.RWMutex
+	lockMessageMockOffset           sync.RWMutex
+	lockMessageMockRelease          sync.RWMutex
+	lockMessageMockUpstreamDone     sync.RWMutex
 )
 
 // Ensure, that MessageMock does implement kafka.Message.
@@ -28,11 +31,20 @@ var _ kafka.Message = &MessageMock{}
 //             CommitFunc: func()  {
 // 	               panic("mock out the Commit method")
 //             },
+//             CommitAndReleaseFunc: func()  {
+// 	               panic("mock out the CommitAndRelease method")
+//             },
 //             GetDataFunc: func() []byte {
 // 	               panic("mock out the GetData method")
 //             },
+//             MarkFunc: func()  {
+// 	               panic("mock out the Mark method")
+//             },
 //             OffsetFunc: func() int64 {
 // 	               panic("mock out the Offset method")
+//             },
+//             ReleaseFunc: func()  {
+// 	               panic("mock out the Release method")
 //             },
 //             UpstreamDoneFunc: func() chan struct{} {
 // 	               panic("mock out the UpstreamDone method")
@@ -47,11 +59,20 @@ type MessageMock struct {
 	// CommitFunc mocks the Commit method.
 	CommitFunc func()
 
+	// CommitAndReleaseFunc mocks the CommitAndRelease method.
+	CommitAndReleaseFunc func()
+
 	// GetDataFunc mocks the GetData method.
 	GetDataFunc func() []byte
 
+	// MarkFunc mocks the Mark method.
+	MarkFunc func()
+
 	// OffsetFunc mocks the Offset method.
 	OffsetFunc func() int64
+
+	// ReleaseFunc mocks the Release method.
+	ReleaseFunc func()
 
 	// UpstreamDoneFunc mocks the UpstreamDone method.
 	UpstreamDoneFunc func() chan struct{}
@@ -61,11 +82,20 @@ type MessageMock struct {
 		// Commit holds details about calls to the Commit method.
 		Commit []struct {
 		}
+		// CommitAndRelease holds details about calls to the CommitAndRelease method.
+		CommitAndRelease []struct {
+		}
 		// GetData holds details about calls to the GetData method.
 		GetData []struct {
 		}
+		// Mark holds details about calls to the Mark method.
+		Mark []struct {
+		}
 		// Offset holds details about calls to the Offset method.
 		Offset []struct {
+		}
+		// Release holds details about calls to the Release method.
+		Release []struct {
 		}
 		// UpstreamDone holds details about calls to the UpstreamDone method.
 		UpstreamDone []struct {
@@ -99,6 +129,32 @@ func (mock *MessageMock) CommitCalls() []struct {
 	return calls
 }
 
+// CommitAndRelease calls CommitAndReleaseFunc.
+func (mock *MessageMock) CommitAndRelease() {
+	if mock.CommitAndReleaseFunc == nil {
+		panic("MessageMock.CommitAndReleaseFunc: method is nil but Message.CommitAndRelease was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockMessageMockCommitAndRelease.Lock()
+	mock.calls.CommitAndRelease = append(mock.calls.CommitAndRelease, callInfo)
+	lockMessageMockCommitAndRelease.Unlock()
+	mock.CommitAndReleaseFunc()
+}
+
+// CommitAndReleaseCalls gets all the calls that were made to CommitAndRelease.
+// Check the length with:
+//     len(mockedMessage.CommitAndReleaseCalls())
+func (mock *MessageMock) CommitAndReleaseCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockMessageMockCommitAndRelease.RLock()
+	calls = mock.calls.CommitAndRelease
+	lockMessageMockCommitAndRelease.RUnlock()
+	return calls
+}
+
 // GetData calls GetDataFunc.
 func (mock *MessageMock) GetData() []byte {
 	if mock.GetDataFunc == nil {
@@ -125,6 +181,32 @@ func (mock *MessageMock) GetDataCalls() []struct {
 	return calls
 }
 
+// Mark calls MarkFunc.
+func (mock *MessageMock) Mark() {
+	if mock.MarkFunc == nil {
+		panic("MessageMock.MarkFunc: method is nil but Message.Mark was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockMessageMockMark.Lock()
+	mock.calls.Mark = append(mock.calls.Mark, callInfo)
+	lockMessageMockMark.Unlock()
+	mock.MarkFunc()
+}
+
+// MarkCalls gets all the calls that were made to Mark.
+// Check the length with:
+//     len(mockedMessage.MarkCalls())
+func (mock *MessageMock) MarkCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockMessageMockMark.RLock()
+	calls = mock.calls.Mark
+	lockMessageMockMark.RUnlock()
+	return calls
+}
+
 // Offset calls OffsetFunc.
 func (mock *MessageMock) Offset() int64 {
 	if mock.OffsetFunc == nil {
@@ -148,6 +230,32 @@ func (mock *MessageMock) OffsetCalls() []struct {
 	lockMessageMockOffset.RLock()
 	calls = mock.calls.Offset
 	lockMessageMockOffset.RUnlock()
+	return calls
+}
+
+// Release calls ReleaseFunc.
+func (mock *MessageMock) Release() {
+	if mock.ReleaseFunc == nil {
+		panic("MessageMock.ReleaseFunc: method is nil but Message.Release was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockMessageMockRelease.Lock()
+	mock.calls.Release = append(mock.calls.Release, callInfo)
+	lockMessageMockRelease.Unlock()
+	mock.ReleaseFunc()
+}
+
+// ReleaseCalls gets all the calls that were made to Release.
+// Check the length with:
+//     len(mockedMessage.ReleaseCalls())
+func (mock *MessageMock) ReleaseCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockMessageMockRelease.RLock()
+	calls = mock.calls.Release
+	lockMessageMockRelease.RUnlock()
 	return calls
 }
 

--- a/kafkatest/mocks_test.go
+++ b/kafkatest/mocks_test.go
@@ -127,13 +127,13 @@ func TestConsumerMock(t *testing.T) {
 
 		Convey("Messages are received in a synchronized fashion", func(c C) {
 			payload1 := []byte{0, 1, 2, 3, 4, 5}
-			message1 := NewMessage(payload1, 0)
+			message1 := NewMessage(payload1, 1)
 
 			payload2 := []byte{6, 7, 8, 9, 0}
-			message2 := NewMessage(payload2, 0)
+			message2 := NewMessage(payload2, 2)
 
 			payload3 := []byte{10, 11, 12, 13, 14}
-			message3 := NewMessage(payload3, 0)
+			message3 := NewMessage(payload3, 3)
 
 			wg := sync.WaitGroup{}
 			receivedAll := false
@@ -145,15 +145,15 @@ func TestConsumerMock(t *testing.T) {
 				defer wg.Done()
 				rxMsg := <-consumerMock.Channels().Upstream
 				c.So(rxMsg, ShouldResemble, message1)
-				rxMsg.Commit()
+				rxMsg.CommitAndRelease()
 
 				rxMsg = <-consumerMock.Channels().Upstream
 				c.So(rxMsg, ShouldResemble, message2)
-				rxMsg.Commit()
+				rxMsg.CommitAndRelease()
 
 				rxMsg = <-consumerMock.Channels().Upstream
 				c.So(rxMsg, ShouldResemble, message3)
-				rxMsg.Commit()
+				rxMsg.CommitAndRelease()
 				receivedAll = true
 			}()
 
@@ -165,6 +165,15 @@ func TestConsumerMock(t *testing.T) {
 				consumerMock.Channels().Upstream <- message2
 				consumerMock.Channels().Upstream <- message3
 				sentAll = true
+			}()
+
+			// Check that the messages are released
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-message1.UpstreamDone()
+				<-message2.UpstreamDone()
+				<-message3.UpstreamDone()
 			}()
 
 			wg.Wait()
@@ -183,6 +192,75 @@ func TestConsumerMock(t *testing.T) {
 		Convey("It can successfully stop listening and then close", func() {
 			validateStopListening(consumerMock)
 			validateCloseConsumer(consumerMock)
+		})
+	})
+}
+
+func TestMessageMock(t *testing.T) {
+
+	Convey("Given a message mock", t, func() {
+		payload := []byte{0, 1, 2, 3, 4, 5}
+		msg := NewMessage(payload, 1)
+
+		Convey("The initial state is not marked or committed", func() {
+			So(msg.marked, ShouldBeFalse)
+			So(msg.committed, ShouldBeFalse)
+		})
+
+		Convey("GetData returns the payload", func() {
+			So(msg.GetData(), ShouldResemble, payload)
+		})
+
+		Convey("Offset returns the message offset", func() {
+			So(msg.Offset(), ShouldEqual, 1)
+		})
+
+		Convey("UpstreamDone returns the upstreamDone channel", func() {
+			So(msg.UpstreamDone(), ShouldResemble, msg.upstreamDoneChan)
+		})
+
+		Convey("Mark marks the message as consumed, but doesn't commit it", func() {
+			msg.Mark()
+			So(msg.marked, ShouldBeTrue)
+			So(msg.committed, ShouldBeFalse)
+		})
+
+		Convey("Commit marks the message as consumed and commits it", func() {
+			msg.Commit()
+			So(msg.marked, ShouldBeTrue)
+			So(msg.committed, ShouldBeTrue)
+		})
+
+		Convey("Release closes the upstreamChannel but doesn't mark the message as consumed and doesn't commit it", func() {
+			go func() {
+				msg.Release()
+			}()
+			_, ok := <-msg.upstreamDoneChan
+			So(ok, ShouldBeFalse)
+			So(msg.marked, ShouldBeFalse)
+			So(msg.committed, ShouldBeFalse)
+		})
+
+		Convey("CommitAndRelease marks the message as consumed, commits it, and closes the upstreamChannel", func() {
+			go func() {
+				msg.CommitAndRelease()
+			}()
+			_, ok := <-msg.upstreamDoneChan
+			So(ok, ShouldBeFalse)
+			So(msg.marked, ShouldBeTrue)
+			So(msg.committed, ShouldBeTrue)
+		})
+
+		Convey("IsMarked returns true if the message is marked as consumed, false otherwise", func() {
+			So(msg.IsMarked(), ShouldBeFalse)
+			msg.marked = true
+			So(msg.IsMarked(), ShouldBeTrue)
+		})
+
+		Convey("IsCommitted returns true if the message is committed, false otherwise", func() {
+			So(msg.IsCommitted(), ShouldBeFalse)
+			msg.committed = true
+			So(msg.IsCommitted(), ShouldBeTrue)
 		})
 	})
 }

--- a/message.go
+++ b/message.go
@@ -12,8 +12,17 @@ type Message interface {
 	// GetData returns the message contents.
 	GetData() []byte
 
-	// Commit the message's offset.
+	// Mark marks the message as consumed, but doesn't commit the offset to the backend
+	Mark()
+
+	// Commit marks the message as consumed and commits its offset to the backend
 	Commit()
+
+	// Release closes the UpstreamDone channel for this message
+	Release()
+
+	// CommitAndRelease marks a message as consumed, commits it and closes the UpstreamDone channel
+	CommitAndRelease()
 
 	// Offset returns the message offset
 	Offset() int64
@@ -39,14 +48,30 @@ func (M SaramaMessage) Offset() int64 {
 	return M.message.Offset
 }
 
-// Commit marks a message as consumed, and then commits the offset to the backend
+// Mark marks the message as consumed, but doesn't commit the offset to the backend
+func (M SaramaMessage) Mark() {
+	M.session.MarkMessage(M.message, "metadata")
+}
+
+// Commit marks the message as consumed, and then commits the offset to the backend
 func (M SaramaMessage) Commit() {
+	M.session.MarkMessage(M.message, "metadata")
+	M.session.Commit()
+}
+
+// Release closes the UpstreamDone channel, but doesn't mark the message or commit the offset
+func (M SaramaMessage) Release() {
+	close(M.upstreamDone)
+}
+
+// CommitAndRelease marks the message as consumed, commits the offset to the backend and releases the UpstreamDone channel
+func (M SaramaMessage) CommitAndRelease() {
 	M.session.MarkMessage(M.message, "metadata")
 	M.session.Commit()
 	close(M.upstreamDone)
 }
 
-// UpstreamDone returns the upstreamDone channel. Closing this channel notifies that the message has been consumed
+// UpstreamDone returns the upstreamDone channel. Closing this channel notifies that the message has been consumed (same effect as calling Release)
 func (M SaramaMessage) UpstreamDone() chan struct{} {
 	return M.upstreamDone
 }


### PR DESCRIPTION
### What

Extended message to expose methods to have finer control on the mark/commit/release process (needed for batch processing):
- Mark() marks the message offset as consumed but doesn't commit it
- Commit() marks the message offset as consumed and commits it (performance impact on Kafka)
- Release() closes the UpstreamDone channel
- CommitAndRelease() marks the message offset, commits it, and then releases the UpstreamDone channel.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Optionally, you can run the examples and verify that they work

### Who can review

Anyone