### PR TITLE
remove noisy 'get metadata' log from healthcheck

### DIFF
--- a/healthcheck.go
+++ b/healthcheck.go
@@ -142,10 +142,6 @@ func validateBroker(ctx context.Context, broker *sarama.Broker, topic string) (r
 		return false, false
 	}
 
-	log.Event(ctx, "get metadata response", log.Data{
-		"response": resp.Topics,
-	})
-
 	for _, metadata := range resp.Topics {
 		if metadata.Name == topic {
 			return true, true


### PR DESCRIPTION
### What

Removed noisy log: `get metadata response` because it was generated every time that a health check is triggered.

### How to review

- Make sure the log line has been removed, and nothing else.

### Who can review

Anyone