### PR TITLE
Add avro package from go-ns

### DIFF
--- a/avro/avro.go
+++ b/avro/avro.go
@@ -1,0 +1,528 @@
+// Package avro provides a user functionality to return the
+// avro encoding of s.
+package avro
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/go-avro/avro"
+)
+
+// Schema contains the schema definition necessary to generate an avro record
+type Schema struct {
+	Definition string
+}
+
+// ErrUnsupportedType is returned if the interface isn't a
+// pointer to a struct
+func ErrUnsupportedType(typ reflect.Kind) error {
+	return fmt.Errorf("Unsupported interface type: %v", typ)
+}
+
+// ErrUnsupportedFieldType is returned for unsupported field types.
+var ErrUnsupportedFieldType = errors.New("Unsupported field type")
+
+// ErrMissingNestedScema is returned when nested schemas are missing from the parent
+var ErrMissingNestedScema = errors.New("nested schema missing from parent")
+
+// Marshal is used to avro encode the interface of s.
+func (schema *Schema) Marshal(s interface{}) ([]byte, error) {
+	v := reflect.ValueOf(s)
+
+	if v.Kind() == reflect.PtrTo(reflect.TypeOf(s)).Kind() {
+		v = reflect.Indirect(v)
+	}
+
+	// Only structs are supported so return an empty result if the passed object
+	// isn't a struct.
+	if v.Kind() != reflect.Struct {
+		return nil, ErrUnsupportedType(v.Kind())
+	}
+
+	// If a pointer to a struct is passed, get the type of the dereferenced object.
+	typ := reflect.TypeOf(s)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	// Check for unsupported interface types
+	err := checkFieldType(v, typ)
+	if err != nil {
+		return nil, err
+	}
+
+	avroSchema, err := avro.ParseSchema(schema.Definition)
+	if err != nil {
+		return nil, err
+	}
+
+	record, err := getRecord(avroSchema, v, typ)
+	if err != nil {
+		return nil, err
+	}
+
+	writer := avro.NewGenericDatumWriter()
+	writer.SetSchema(avroSchema)
+
+	buffer := new(bytes.Buffer)
+	encoder := avro.NewBinaryEncoder(buffer)
+
+	err = writer.Write(record, encoder)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// Unmarshal is used to parse the avro encoded data and store the
+// result in the value pointed to by s.
+func (schema *Schema) Unmarshal(message []byte, s interface{}) error {
+	v := reflect.ValueOf(s)
+	vp := reflect.ValueOf(s)
+
+	if v.Kind() == reflect.PtrTo(reflect.TypeOf(s)).Kind() {
+		v = reflect.Indirect(v)
+	}
+
+	// Only structs are supported so return an empty result if the passed object
+	// isn't a struct.
+	if v.Kind() != reflect.Struct {
+		return ErrUnsupportedType(v.Kind())
+	}
+
+	// If a pointer to a struct is passed, get the type of the dereferenced object.
+	typ := reflect.TypeOf(s)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	return populateStructFromSchema(schema.Definition, message, typ, v, vp)
+}
+
+func checkFieldType(v reflect.Value, t reflect.Type) error {
+	for i := 0; i < v.NumField(); i++ {
+		fieldTag := t.Field(i).Tag.Get("avro")
+		if fieldTag == "-" {
+			continue
+		}
+		fieldType := t.Field(i)
+
+		if !isValidType(fieldType.Type.Kind()) {
+			return ErrUnsupportedFieldType
+		}
+	}
+
+	return nil
+}
+
+func generateDecodedRecord(schema string, message []byte) (*avro.GenericRecord, error) {
+	avroSchema, err := avro.ParseSchema(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := avro.NewGenericDatumReader()
+	reader.SetSchema(avroSchema)
+	decoder := avro.NewBinaryDecoder(message)
+	decodedRecord := avro.NewGenericRecord(avroSchema)
+
+	err = reader.Read(decodedRecord, decoder)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedRecord, nil
+}
+
+func getNestedSchema(avroSchema avro.Schema, fieldTag string, v reflect.Value, typ reflect.Type) (avro.Schema, error) {
+	// Unmarshal parent avro schema into map
+	var schemaMap map[string]interface{}
+	if err := json.Unmarshal([]byte(avroSchema.String()), &schemaMap); err != nil {
+		return nil, err
+	}
+
+	// Get fields section from parent schema map
+	fields := schemaMap["fields"].([]interface{})
+	for _, field := range fields {
+		var fld map[string]interface{}
+		var ok bool
+
+		if fld, ok = field.(map[string]interface{}); !ok {
+			continue
+		}
+
+		// Iterate through each field until the nested schema field is found
+		if fld["name"].(string) == fieldTag {
+			var avroFieldType map[string]interface{}
+
+			// The nested schema is inside the type element of the required field
+			if avroFieldType, ok = fld["type"].(map[string]interface{}); !ok {
+				var avroFieldTypes []interface{}
+				if avroFieldTypes, ok = fld["type"].([]interface{}); !ok {
+					continue
+				}
+
+				// If the nested schema could potentially be "null", then the schema is the second type
+				// element rather than the first
+				if avroFieldType = avroFieldTypes[1].(map[string]interface{}); !ok {
+					continue
+				}
+			}
+
+			// Marshal the nested schema map into json
+			nestedSchemaBytes, err := json.Marshal(avroFieldType)
+			if err != nil {
+				return nil, err
+			}
+
+			return avro.ParseSchema(string(nestedSchemaBytes))
+		}
+	}
+	return nil, ErrMissingNestedScema
+}
+
+func getRecord(avroSchema avro.Schema, v reflect.Value, typ reflect.Type) (*avro.GenericRecord, error) {
+	record := avro.NewGenericRecord(avroSchema)
+
+	for i := 0; i < v.NumField(); i++ {
+		fieldTag := typ.Field(i).Tag.Get("avro")
+		if fieldTag == "-" {
+			continue
+		}
+		fieldName := typ.Field(i).Name
+
+		switch typ.Field(i).Type.Kind() {
+		case reflect.Bool:
+			value := v.FieldByName(fieldName).Bool()
+			record.Set(fieldTag, value)
+		case reflect.String:
+			value := v.FieldByName(fieldName).String()
+			record.Set(fieldTag, value)
+		case reflect.Int32:
+			value := v.FieldByName(fieldName).Interface().(int32)
+			record.Set(fieldTag, value)
+		case reflect.Int64:
+			value := v.FieldByName(fieldName).Interface().(int64)
+			record.Set(fieldTag, value)
+		case reflect.Map:
+			if err := marshalMap(record, v, i, fieldTag, avroSchema); err != nil {
+				return nil, err
+			}
+		case reflect.Slice:
+			if err := marshalSlice(record, v, i, fieldTag, avroSchema); err != nil {
+				return nil, err
+			}
+		case reflect.Struct:
+			nestedSchema, err := getNestedSchema(avroSchema, fieldTag, v, typ)
+			if err != nil {
+				return nil, err
+			}
+
+			nestedRecord, err := getRecord(nestedSchema, v.Field(i), typ.Field(i).Type)
+			if err != nil {
+				return nil, err
+			}
+
+			record.Set(fieldTag, nestedRecord)
+		}
+	}
+
+	return record, nil
+}
+
+func isValidType(kind reflect.Kind) bool {
+	supportedTypes := []reflect.Kind{
+		reflect.Bool,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Map,
+		reflect.Slice,
+		reflect.String,
+		reflect.Struct,
+	}
+
+	for _, supportedType := range supportedTypes {
+		if supportedType == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func marshalSlice(record *avro.GenericRecord, v reflect.Value, i int, fieldTag string, avroSchema avro.Schema) error {
+	// This switch statement will need to be extended to support other native types,
+	// Currently supports strings and structs.
+	switch v.Field(i).Type().Elem().Kind() {
+	case reflect.String:
+		slice := marshalStringSlice(v, i)
+		record.Set(fieldTag, slice)
+	case reflect.Struct:
+		slice, err := marshalStructSlice(v, i, avroSchema, fieldTag)
+		if err != nil {
+			return err
+		}
+		record.Set(fieldTag, slice)
+	}
+	return nil
+}
+
+func marshalStringSlice(v reflect.Value, i int) []interface{} {
+	vals := v.Field(i)
+	var slice []interface{}
+	for j := 0; j < vals.Len(); j++ {
+		slice = append(slice, vals.Index(j).Interface())
+	}
+	return slice
+}
+
+func marshalStructSlice(v reflect.Value, i int, avroSchema avro.Schema, fieldTag string) ([]interface{}, error) {
+	vals := v.Field(i)
+	var slice []interface{}
+	for j := 0; j < vals.Len(); j++ {
+		arraySchema, err := getArraySchema(avroSchema, fieldTag)
+		if err != nil {
+			return nil, err
+		}
+
+		arrayRecord, err := getRecord(arraySchema, vals.Index(j), v.Field(i).Type().Elem())
+		if err != nil {
+			return nil, err
+		}
+
+		slice = append(slice, arrayRecord)
+	}
+	return slice, nil
+}
+
+func getArraySchema(avroSchema avro.Schema, fieldTag string) (avro.Schema, error) {
+	var schemaMap map[string]interface{}
+	// Unmarshal the parent schema into a map
+	if err := json.Unmarshal([]byte(avroSchema.String()), &schemaMap); err != nil {
+		return nil, err
+	}
+
+	fields := schemaMap["fields"].([]interface{})
+	for _, field := range fields {
+		var fld map[string]interface{}
+		var ok bool
+
+		if fld, ok = field.(map[string]interface{}); !ok {
+			continue
+		}
+
+		// Iterate through fields in schema until fieldTag matches the name element
+		// of the field
+		if fld["name"].(string) == fieldTag {
+			// The array schema will be inside the type element of the requested field.
+			// Marshal this schema back to json and return
+			arraySchemaBytes, err := json.Marshal(fld["type"])
+			if err != nil {
+				return nil, err
+			}
+
+			return avro.ParseSchema(string(arraySchemaBytes))
+		}
+	}
+
+	return nil, ErrMissingNestedScema
+}
+
+func populateItem(nestedMap map[string]interface{}, typ reflect.Type) reflect.Value {
+	// Create a new instance of required struct type
+	v := reflect.Indirect(reflect.New(typ))
+	for i := 0; i < v.NumField(); i++ {
+		field := typ.Field(i).Tag.Get("avro")
+		fieldValue := nestedMap[field]
+		if fieldValue != nil {
+			if v.Field(i).Kind() == reflect.Struct {
+				setNestedStructs(fieldValue.(map[string]interface{}), v.Field(i), typ.Field(i).Type)
+				continue
+			}
+			value := reflect.ValueOf(fieldValue)
+			switch typ.Field(i).Type.Kind() {
+			case reflect.Slice:
+				sliceInterface := fieldValue.([]interface{})
+				sliceString := make([]string, len(sliceInterface))
+				for _, val := range sliceInterface {
+					sliceString = append(sliceString, val.(string))
+				}
+				value = reflect.ValueOf(sliceString)
+			case reflect.Map:
+				mapInterface := fieldValue.(map[string]interface{})
+				if len(mapInterface) == 0 {
+					continue
+				}
+				mapString := make(map[string]string, len(mapInterface))
+				for key, val := range mapInterface {
+					mapString[key] = val.(string)
+				}
+				value = reflect.ValueOf(mapString)
+			}
+			v.Field(i).Set(value)
+		}
+	}
+	return v
+}
+
+func populateStructFromSchema(schema string, message []byte, typ reflect.Type, v, vp reflect.Value) error {
+	decodedRecord, err := generateDecodedRecord(schema, message)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < v.NumField(); i++ {
+		field := typ.Field(i).Tag.Get("avro")
+		if field == "-" {
+			continue
+		}
+		rawFieldName := typ.Field(i).Name
+		fieldName := vp.Elem().FieldByName(rawFieldName)
+
+		value := decodedRecord.Get(field)
+
+		if fieldName.IsValid() {
+			switch v.Field(i).Type().Kind() {
+			case reflect.Map:
+				value = unmarshalMap(value)
+			case reflect.Slice:
+				switch v.Field(i).Type().Elem().Kind() {
+				case reflect.String:
+					value = unmarshalStringSlice(value)
+				case reflect.Struct:
+					v, err = unmarshalStructSlice(value, v, i)
+					if err != nil {
+						return err
+					}
+					continue
+				default:
+					return ErrUnsupportedType(v.Field(i).Type().Elem().Kind())
+				}
+
+			case reflect.Struct:
+				value, err = unmarshalStruct(value, v, i)
+				if err != nil {
+					return err
+				}
+			}
+
+			fieldName.Set(reflect.ValueOf(value))
+		}
+	}
+
+	return nil
+}
+
+func setNestedStructs(nestedMap map[string]interface{}, v reflect.Value, typ reflect.Type) {
+	for i := 0; i < v.NumField(); i++ {
+		field := typ.Field(i).Tag.Get("avro")
+		fieldValue := nestedMap[field]
+		if fieldValue != nil {
+			if v.Field(i).Kind() == reflect.Struct {
+				setNestedStructs(fieldValue.(map[string]interface{}), v.Field(i), typ.Field(i).Type)
+				continue
+			}
+			value := reflect.ValueOf(fieldValue)
+			switch typ.Field(i).Type.Kind() {
+			case reflect.Slice:
+				sliceInterface := fieldValue.([]interface{})
+				sliceString := make([]string, len(sliceInterface))
+				for i, val := range sliceInterface {
+					sliceString[i] = val.(string)
+				}
+				value = reflect.ValueOf(sliceString)
+			case reflect.Map:
+				mapInterface := fieldValue.(map[string]interface{})
+				if len(mapInterface) == 0 {
+					continue
+				}
+				mapString := make(map[string]string, len(mapInterface))
+				for key, val := range mapInterface {
+					mapString[key] = val.(string)
+				}
+				value = reflect.ValueOf(mapString)
+			}
+			v.Field(i).Set(value)
+		}
+	}
+}
+
+func marshalMap(record *avro.GenericRecord, v reflect.Value, i int, fieldTag string, avroSchema avro.Schema) error {
+	// This switch statement will need to be extended to support other native types,
+	// Currently supports strings
+	switch v.Field(i).Type().Elem().Kind() {
+	case reflect.String:
+		stringMap := marshalStringMap(v, i)
+		record.Set(fieldTag, stringMap)
+	}
+	return nil
+}
+
+func marshalStringMap(v reflect.Value, i int) map[string]string {
+	vals := v.Field(i)
+	stringMap := make(map[string]string)
+	for _, key := range vals.MapKeys() {
+		stringMap[key.String()] = vals.MapIndex(key).String()
+	}
+	return stringMap
+}
+
+func unmarshalStringSlice(value interface{}) []string {
+	sliceInterface := value.([]interface{})
+	sliceString := make([]string, len(sliceInterface))
+	for _, val := range sliceInterface {
+		sliceString = append(sliceString, val.(string))
+	}
+	return sliceString
+}
+
+func unmarshalStructSlice(value interface{}, v reflect.Value, i int) (reflect.Value, error) {
+	sliceInterface := value.([]interface{})
+	sliceType := v.Field(i).Type().Elem()
+	emptySlice := reflect.MakeSlice(reflect.SliceOf(sliceType), 0, 0)
+	for _, val := range sliceInterface {
+		record := val.(*avro.GenericRecord)
+
+		var dataMap map[string]interface{}
+		if err := json.Unmarshal([]byte(record.String()), &dataMap); err != nil {
+			return v, err
+		}
+		item := populateItem(dataMap, v.Field(i).Type().Elem())
+		emptySlice = reflect.Append(emptySlice, item)
+		v.Field(i).Set(emptySlice)
+	}
+	return v, nil
+}
+
+func unmarshalStruct(val interface{}, v reflect.Value, i int) (interface{}, error) {
+	record := val.(*avro.GenericRecord)
+
+	var dataMap map[string]interface{}
+	if err := json.Unmarshal([]byte(record.String()), &dataMap); err != nil {
+		return v, err
+	}
+
+	item := populateItem(dataMap, v.Field(i).Type())
+
+	return item.Interface(), nil
+}
+
+func unmarshalMap(value interface{}) map[string]string {
+	if value == nil {
+		return nil
+	}
+	return unmarshalStringMap(value)
+}
+
+func unmarshalStringMap(value interface{}) map[string]string {
+	mapInterface := value.(map[string]interface{})
+	mapString := make(map[string]string, len(mapInterface))
+	for key, val := range mapInterface {
+		mapString[key] = val.(string)
+	}
+	return mapString
+}

--- a/avro/avro_test.go
+++ b/avro/avro_test.go
@@ -1,0 +1,448 @@
+package avro
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-avro/avro"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type stringMap map[string]string
+
+func TestUnitMarshal(t *testing.T) {
+	Convey("Nested objects", t, func() {
+		schema := &Schema{
+			Definition: nestedObjectSchema,
+		}
+
+		data := &NestedTestData{
+			Team: "Tottenham",
+			Footballer: FootballerName{
+				Surname:  "Kane",
+				Forename: "Harry",
+				AKA:      map[string]string{"Hurricane": "positive"},
+			},
+			AKA: map[string]string{
+				"Spurs":          "team name",
+				"The Lilywhites": "another team name",
+			},
+			Silverware: map[string]string{"FA Cup": "1900-01"},
+			Stats:      int32(10),
+		}
+
+		bufferBytes, err := schema.Marshal(data)
+		So(err, ShouldBeNil)
+		So(bufferBytes, ShouldNotBeNil)
+
+		var footballMessage NestedTestData
+		exampleEvent := &Schema{
+			Definition: nestedObjectSchema,
+		}
+
+		err = exampleEvent.Unmarshal(bufferBytes, &footballMessage)
+		So(err, ShouldBeNil)
+		So(footballMessage.Team, ShouldEqual, "Tottenham")
+		So(footballMessage.Footballer.Surname, ShouldEqual, "Kane")
+		So(footballMessage.Footballer.Forename, ShouldEqual, "Harry")
+		So(footballMessage.Footballer.AKA, ShouldResemble, map[string]string{"Hurricane": "positive"})
+		So(footballMessage.AKA, ShouldResemble, map[string]string{"Spurs": "team name", "The Lilywhites": "another team name"})
+		So(footballMessage.Silverware, ShouldResemble, map[string]string{"FA Cup": "1900-01"})
+		So(footballMessage.Stats, ShouldEqual, int32(10))
+	})
+
+	Convey("Nested object empty", t, func() {
+		schema := &Schema{
+			Definition: nestedObjectSchema,
+		}
+
+		data := &NestedTestData{
+			Team:       "Tottenham",
+			Footballer: FootballerName{},
+		}
+
+		bufferBytes, err := schema.Marshal(data)
+		So(err, ShouldBeNil)
+		So(bufferBytes, ShouldNotBeNil)
+
+		var footballMessage NestedTestData
+		exampleEvent := &Schema{
+			Definition: nestedObjectSchema,
+		}
+
+		err = exampleEvent.Unmarshal(bufferBytes, &footballMessage)
+		So(err, ShouldBeNil)
+		So(footballMessage.Team, ShouldEqual, "Tottenham")
+		So(footballMessage.Footballer, ShouldResemble, FootballerName{})
+		So(footballMessage.Stats, ShouldEqual, 0)
+		// Note: AKA was empty, so remains empty (no "null" default)
+		So(footballMessage.AKA, ShouldNotBeNil)
+		So(footballMessage.AKA, ShouldResemble, map[string]string{})
+		// Note: Silverware was empty, but has a default of nil
+		So(footballMessage.Silverware, ShouldBeNil)
+	})
+
+	Convey("Successfully marshal data", t, func() {
+		schema := &Schema{
+			Definition: testSchema,
+		}
+
+		data := &testData{
+			Manager:         "Pardew, Alan",
+			TeamName:        "Crystal Palace FC",
+			Owner:           "Long, Martin",
+			Sport:           "Football",
+			URI:             "http://8080/cpfc.com",
+			HasChangedName:  false,
+			NumberOfPlayers: int32(24),
+			PayPerWeek:      int64(539457394875390485),
+		}
+
+		bufferBytes, err := schema.Marshal(data)
+		So(err, ShouldBeNil)
+		So(bufferBytes, ShouldNotBeNil)
+	})
+
+	Convey("Successfully marshal data missing uri", t, func() {
+		schema := &Schema{
+			Definition: testSchema,
+		}
+
+		data := &testData1{
+			Manager:         "Pardew, Alan",
+			HasChangedName:  false,
+			NumberOfPlayers: int32(24),
+			URI:             "http://8080/cpfc.com",
+		}
+
+		bufferBytes, err := schema.Marshal(data)
+		So(err, ShouldBeNil)
+		So(bufferBytes, ShouldNotBeNil)
+	})
+
+	Convey("Marshal should return an error unless given a pointer to a struct", t, func() {
+		schema := &Schema{
+			Definition: testSchema,
+		}
+
+		data := "string"
+		bufferBytes, err := schema.Marshal(data)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldHaveSameTypeAs, ErrUnsupportedType(reflect.ValueOf(data).Kind()))
+		So(bufferBytes, ShouldBeNil)
+	})
+
+	Convey("Marshal should return an error if field is of the wrong type", t, func() {
+		schema := &Schema{
+			Definition: testSchema,
+		}
+
+		data := &testData2{
+			Manager:        "Pardew, Alan",
+			NumberOfYouths: 10,
+		}
+
+		bufferBytes, err := schema.Marshal(data)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldEqual, ErrUnsupportedFieldType)
+		So(bufferBytes, ShouldBeNil)
+	})
+}
+
+// Test checkFieldType function
+func TestUnitCheckFieldType(t *testing.T) {
+	Convey("Successfully return without error", t, func() {
+		_, v, t := setUp(testSchema, 1)
+
+		err := checkFieldType(v, t)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Error on unsupported field type", t, func() {
+		_, v, t := setUp(testSchema, 2)
+
+		err := checkFieldType(v, t)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, ErrUnsupportedFieldType)
+	})
+}
+
+// Test isValidType function
+func TestUnitIsValidType(t *testing.T) {
+	Convey("Return true for supported types", t, func() {
+		Convey("returned true for boolean type", func() {
+			isValid := isValidType(reflect.Bool)
+			So(isValid, ShouldEqual, true)
+		})
+
+		Convey("returned true for int32 type", func() {
+			isValid := isValidType(reflect.Int32)
+			So(isValid, ShouldEqual, true)
+		})
+
+		Convey("returned true for int64 type", func() {
+			isValid := isValidType(reflect.Int64)
+			So(isValid, ShouldEqual, true)
+		})
+
+		Convey("returned true for slice type", func() {
+			isValid := isValidType(reflect.Slice)
+			So(isValid, ShouldEqual, true)
+		})
+
+		Convey("returned true for string type", func() {
+			isValid := isValidType(reflect.String)
+			So(isValid, ShouldEqual, true)
+		})
+
+		Convey("returned true for map type", func() {
+			isValid := isValidType(reflect.Map)
+			So(isValid, ShouldEqual, true)
+		})
+
+		Convey("returned true for struct type", func() {
+			isValid := isValidType(reflect.Struct)
+			So(isValid, ShouldEqual, true)
+		})
+	})
+
+	Convey("Return false for unsupported type", t, func() {
+		isValid := isValidType(reflect.Float32)
+		So(isValid, ShouldEqual, false)
+	})
+}
+
+// Test getRecord function
+func TestUnitGetRecord(t *testing.T) {
+	Convey("Successfully return a generic avro record", t, func() {
+		Convey("record generated without a nested object", func() {
+			avroSchema, v, typ := setUp(testSchema, 1)
+
+			record, err := getRecord(avroSchema, v, typ)
+			So(err, ShouldBeNil)
+			So(record, ShouldNotBeNil)
+			So(record, ShouldHaveSameTypeAs, avro.NewGenericRecord(avroSchema))
+		})
+
+		Convey("record generated with array of strings", func() {
+			avroSchema, v, typ := setUp(testArraySchema, 3)
+
+			record, err := getRecord(avroSchema, v, typ)
+			So(err, ShouldBeNil)
+			So(record, ShouldNotBeNil)
+			So(record, ShouldHaveSameTypeAs, avro.NewGenericRecord(avroSchema))
+			So(record.Get("winning_years"), ShouldResemble, []interface{}{"1934", "1972", "1999"})
+		})
+
+		Convey("record generated with missing array of strings", func() {
+			avroSchema, v, typ := setUp(testArraySchema, 5)
+
+			record, err := getRecord(avroSchema, v, typ)
+			So(err, ShouldBeNil)
+			So(record, ShouldNotBeNil)
+			So(record, ShouldHaveSameTypeAs, avro.NewGenericRecord(avroSchema))
+			So(record.Get("winning_years"), ShouldResemble, []interface{}(nil))
+		})
+
+		Convey("record generated with nested array", func() {
+			avroSchema, v, typ := setUp(testNestedArraySchema, 4)
+
+			record, err := getRecord(avroSchema, v, typ)
+
+			So(err, ShouldBeNil)
+			So(record, ShouldNotBeNil)
+			So(record, ShouldHaveSameTypeAs, avro.NewGenericRecord(avroSchema))
+			So(record.Get("team"), ShouldResemble, "Doncaster")
+			So(record.Get("footballers"), ShouldNotBeEmpty)
+		})
+	})
+}
+
+// Test marshalSlice function
+func TestUnitMarshalSlice(t *testing.T) {
+	Convey("Successfully marshal string slice", t, func() {
+		avroSchema, v, typ := setUp(testArraySchema, 3)
+		record, _ := getRecord(avroSchema, v, typ)
+
+		err := marshalSlice(record, v, 0, "string_slice", avroSchema)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Successfully marshal struct slice", t, func() {
+		avroSchema, v, typ := setUp(testNestedArraySchema, 4)
+		record, _ := getRecord(avroSchema, v, typ)
+
+		err := marshalSlice(record, v, 1, "footballers", avroSchema)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Fail to marshal struct slice", t, func() {
+		avroSchema, v, typ := setUp(testNestedArraySchema, 4)
+		record, _ := getRecord(avroSchema, v, typ)
+
+		err := marshalSlice(record, v, 1, "footballer", avroSchema)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, ErrMissingNestedScema)
+	})
+}
+
+// Test marshalStringSlice function
+func TestUnitMarshalStringSlice(t *testing.T) {
+	Convey("Successfully marshal string slice", t, func() {
+		_, v, _ := setUp(testArraySchema, 3)
+
+		slice := marshalStringSlice(v, 0)
+		So(slice, ShouldNotBeEmpty)
+		So(slice, ShouldResemble, []interface{}{"1934", "1972", "1999"})
+	})
+}
+
+// Test marshalStructSlice function
+func TestUnitMarshalStructSlice(t *testing.T) {
+	Convey("Successfully marshal struct slice", t, func() {
+		avroSchema, v, _ := setUp(testNestedArraySchema, 4)
+
+		slice, err := marshalStructSlice(v, 1, avroSchema, "footballers")
+		So(err, ShouldBeNil)
+		So(slice, ShouldNotBeEmpty)
+	})
+
+	Convey("Throws error due to missing nested schema", t, func() {
+		avroSchema, v, _ := setUp(testNestedArraySchema, 4)
+
+		slice, err := marshalStructSlice(v, 1, avroSchema, "footballer")
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, ErrMissingNestedScema)
+		So(slice, ShouldBeNil)
+	})
+}
+
+// Test getArraySchema function
+func TestUnitGetArraySchema(t *testing.T) {
+	avroSchema, _, _ := setUp(testSchema, 0)
+
+	Convey("Successfully retrieve array schema", t, func() {
+		newSchema, err := getArraySchema(avroSchema, "manager")
+		So(err, ShouldBeNil)
+		So(newSchema, ShouldNotBeEmpty)
+	})
+
+	Convey("Error retrieving array schema", t, func() {
+		newSchema, err := getArraySchema(avroSchema, "managers")
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, ErrMissingNestedScema)
+		So(newSchema, ShouldBeNil)
+	})
+}
+
+// Test getNestedSchema function
+func TestUnitGetNestedSchema(t *testing.T) {
+	Convey("Successfully retrieve nested schema", t, func() {
+		avroSchema, v, t := setUp(testNestedArraySchema, 4)
+
+		newSchema, err := getNestedSchema(avroSchema, "footballers", v, t)
+		So(err, ShouldBeNil)
+		So(newSchema, ShouldNotBeEmpty)
+	})
+
+	Convey("Error retrieving nested schema", t, func() {
+		avroSchema, v, t := setUp(testNestedArraySchema, 4)
+
+		newSchema, err := getNestedSchema(avroSchema, "footballer", v, t)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldResemble, ErrMissingNestedScema)
+		So(newSchema, ShouldBeNil)
+	})
+}
+
+// TODO Test Unmarshal function
+
+// TODO -- Test populateStructFromSchema function
+
+// TODO -- -- Test generateDecodedRecord function
+
+// TODO -- -- Test unmarshalStringSlice function
+
+// TODO -- -- Test unmarshalStructSlice function
+
+// TODO -- -- -- Test populateNestedArrayItem function
+
+// TODO -- -- -- -- Test setNestedStructs function
+
+func setUp(testSchema string, dataSet int) (avro.Schema, reflect.Value, reflect.Type) {
+	avroSchema, _ := avro.ParseSchema(testSchema)
+
+	var (
+		v   reflect.Value
+		typ reflect.Type
+	)
+
+	switch dataSet {
+	case 1:
+		testData := &testData1{
+			Manager:         "Pardew, Alan",
+			HasChangedName:  false,
+			NumberOfPlayers: int32(24),
+			PayPerWeek:      int64(539457394875390485),
+		}
+
+		v = reflect.ValueOf(testData)
+		typ = reflect.TypeOf(testData)
+	case 2:
+		testData := &testData2{
+			Manager:         "Pardew, Alan",
+			HasChangedName:  false,
+			NumberOfPlayers: int32(24),
+			NumberOfYouths:  6,
+		}
+
+		v = reflect.ValueOf(testData)
+		typ = reflect.TypeOf(testData)
+	case 3:
+		var winningYears []string
+		winningYears = append(winningYears, "1934", "1972", "1999")
+		testData := &testData3{
+			WinningYears: winningYears,
+		}
+
+		v = reflect.ValueOf(testData)
+		typ = reflect.TypeOf(testData)
+	case 4:
+		testData := &testData4{
+			Team: "Doncaster",
+			Footballers: []Footballer{
+				{
+					Email: "jgregory@gmail.com",
+					Name:  "jack gregory",
+				},
+				{
+					Email: "pdoherty@gmail.com",
+					Name:  "paul doherty",
+				},
+			},
+		}
+
+		v = reflect.ValueOf(testData)
+		typ = reflect.TypeOf(testData)
+	case 5:
+		var winningYears []string
+		testData := &testData5{
+			WinningYears: winningYears,
+		}
+
+		v = reflect.ValueOf(testData)
+		typ = reflect.TypeOf(testData)
+	default:
+		testData := &testData1{
+			Manager: "Pardew, Alan",
+		}
+
+		v = reflect.ValueOf(testData)
+		typ = reflect.TypeOf(testData)
+	}
+
+	v = reflect.Indirect(v)
+	typ = typ.Elem()
+
+	return avroSchema, v, typ
+}

--- a/avro/test_data.go
+++ b/avro/test_data.go
@@ -1,0 +1,181 @@
+package avro
+
+var testSchema = `{ "type": "record",
+ "name": "example",
+ "fields": [
+    {"name": "manager", "type": "string"},
+    {"name": "team_name", "type": "string"},
+    {"name": "ownerOfTeam", "type": "string"},
+    {"name": "kind-of-sport", "type": "string"},
+    {"name": "uri", "type": "string", "default": ""},
+    {"name": "has_changed_name", "type": "boolean"},
+    {"name": "number_of_players", "type": "int"},
+    {"name": "pay_per_week", "type": "long"}
+ ]
+}`
+
+var testArraySchema = `{ "type": "record",
+ "name": "example",
+ "fields": [
+      {"name": "winning_years","type":["null",{"type":"array","items":"string"}]},
+ ]
+}`
+
+var testNestedArraySchema = `{
+  "type": "record",
+  "name": "example",
+  "fields": [
+        {
+            "name" : "team",
+            "type" : "string"
+        },
+        {
+            "name" : "footballers",
+            "type" : {
+                "type" : "array",
+                "items" : {
+                    "name" : "footballer",
+                    "type" : "record",
+                    "fields" : [
+                        {
+                            "name" : "email",
+                            "type" : "string"
+                        },
+                        {
+                            "name": "name",
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+`
+
+var nestedObjectSchema = `{
+	"type": "record",
+	"name": "nested-object-example",
+	"fields": [
+		{
+			"name": "team",
+			"type": "string"
+		},
+		{
+			"name": "footballer",
+			"type": {
+				"name": "footballer-name",
+				"type": "record",
+				"fields": [
+					{
+						"name": "surname",
+						"type": "string",
+						"default": ""
+					},
+					{
+						"name": "forename",
+						"type": "string",
+						"default": ""
+					},
+                                	{
+                                        	"name": "aka",
+                                                "type": {
+                                                        "type": "map",
+                                                        "values": "string"
+                                		}
+                                        }
+				]
+			}
+		},
+		{
+			"name": "aka",
+			"type": {
+					"type": "map",
+					"values": "string"
+				}
+		},
+		{
+			"name": "silverware",
+			"default": null,
+			"type": [
+				"null",
+				{
+					"type": "map",
+					"values": "string"
+				}
+			]
+		},
+		{
+			"name": "stats",
+			"type": [
+				"int",
+				"null"
+			]
+		}
+	]
+}`
+
+// NestedTestData represents an object nested within an object
+type NestedTestData struct {
+	Team       string            `avro:"team"`
+	Footballer FootballerName    `avro:"footballer"`
+	Stats      int32             `avro:"stats"`
+	AKA        map[string]string `avro:"aka"`
+	Silverware map[string]string `avro:"silverware"`
+}
+
+// FootballerName represents an object containing the footballers name
+type FootballerName struct {
+	Surname  string            `avro:"surname"`
+	Forename string            `avro:"forename"`
+	AKA      map[string]string `avro:"aka"`
+}
+
+type testData struct {
+	Manager         string `avro:"manager"`
+	TeamName        string `avro:"team_name"`
+	Owner           string `avro:"ownerOfTeam"`
+	Sport           string `avro:"kind-of-sport"`
+	URI             string `avro:"uri"`
+	HasChangedName  bool   `avro:"has_changed_name"`
+	NumberOfPlayers int32  `avro:"number_of_players"`
+	PayPerWeek      int64  `avro:"pay_per_week"`
+}
+
+type testData1 struct {
+	Manager         string `avro:"manager"`
+	TeamName        string `avro:"team_name"`
+	Owner           string `avro:"ownerOfTeam"`
+	Sport           string `avro:"kind-of-sport"`
+	URI             string `avro:"-"`
+	HasChangedName  bool   `avro:"has_changed_name"`
+	NumberOfPlayers int32  `avro:"number_of_players"`
+	PayPerWeek      int64  `avro:"pay_per_week"`
+}
+
+type testData2 struct {
+	Manager         string `avro:"manager"`
+	URI             string `avro:"-"`
+	HasChangedName  bool   `avro:"has_changed_name"`
+	NumberOfPlayers int32  `avro:"number_of_players"`
+	NumberOfYouths  int    `avro:"number_of_youths"`
+}
+
+type testData3 struct {
+	WinningYears []string `avro:"winning_years"`
+}
+
+type testData4 struct {
+	Team        string       `avro:"team"`
+	Footballers []Footballer `avro:"footballers"`
+}
+
+type testData5 struct {
+	WinningYears []string `avro:"winning_years"`
+}
+
+// Footballer represents the details of a footballer
+type Footballer struct {
+	Email string `avro:"email"`
+	Name  string `avro:"name"`
+}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/Shopify/sarama v1.27.2
+	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/smartystreets/goconvey v1.6.4
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
+	gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.10.2 h1:19ARM85nVi4xH7xPXuc5eM/udya5ieh7b/Sv+d844Tk=
 github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
+github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 h1:yswqe8UdKNWn4kjh1YTaAbvOSPeg95xhW7h4qeICL5E=
+github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dmFPk4Z+bijIAhJoGgeBfyOKXMduhvdJPA=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
@@ -99,12 +101,12 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1P+/ZFC/IKythI5RzrnRg=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183 h1:PGIdqvwfpMUyUP+QAlAnKTSWQ671SmYjoou2/5j7HXk=
+gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183/go.mod h1:FvqrFXt+jCsyQibeRv4xxEJBL5iG2DDW5aeJwzDiq4A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### What

Added the avro package used by all of our kafka services into this library to reduce dependencies on [deprecated go-ns library](https://github.com/ONSdigital/go-ns/tree/master/avro).
This does not include any review of or improvements to the library, but is just a lift and shift.

### How to review

Check new avro package compiles and can be swapped out (github.com/ONSdigital/go-ns/avro -> github.com/ONSdigital/dp-kafka/avro) seamlessly

### Who can review

anyone with occasion to test a kafka service
