### PR TITLE
Update log.go requirement to v2 in go.mod and imports.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ audit:
 build:
 	go build ./...
 .PHONY: build
+
+.PHONY: lint
+lint:
+	exit

--- a/admin.go
+++ b/admin.go
@@ -1,7 +1,8 @@
 package kafka
 
 import (
-	"github.com/ONSdigital/log.go/log"
+	"context"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
 )
 
@@ -32,11 +33,11 @@ func NewAdmin(brokerAddrs []string, pConfig *AdminConfig) (sarama.ClusterAdmin, 
 
 func (t Acls) Apply(adm sarama.ClusterAdmin) error {
 	for _, acl := range t {
-		log.Event(nil, "creating ACL", log.Data{"res": acl.Resource, "acl": acl.Acl})
+		log.Info(context.Background(), "creating ACL", log.Data{"res": acl.Resource, "acl": acl.Acl})
 		if err := adm.CreateACL(acl.Resource, acl.Acl); err != nil {
 			return err
 		}
-		log.Event(nil, "created ACL")
+		log.Info(context.Background(), "created ACL")
 	}
 	return nil
 }

--- a/channels.go
+++ b/channels.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"context"
 
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 // channel names
@@ -66,7 +66,7 @@ func (consumerChannels *ConsumerGroupChannels) LogErrors(ctx context.Context, er
 		for {
 			select {
 			case err := <-consumerChannels.Errors:
-				log.Event(ctx, errMsg, log.ERROR, log.Error(err))
+				log.Error(ctx, errMsg, err)
 			case <-consumerChannels.Closer:
 				return
 			}
@@ -105,7 +105,7 @@ func (producerChannels *ProducerChannels) LogErrors(ctx context.Context, errMsg 
 		for {
 			select {
 			case err := <-producerChannels.Errors:
-				log.Event(ctx, errMsg, log.ERROR, log.Error(err))
+				log.Error(ctx, errMsg, err)
 			case <-producerChannels.Closer:
 				return
 			}

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,0 +1,15 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.15.7
+
+inputs:
+  - name: dp-kafka
+
+run:
+  path: dp-kafka/ci/scripts/lint.sh

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.7
+    tag: latest
 
 inputs:
   - name: dp-kafka

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-kafka
+  make lint
+popd

--- a/consumer_group_handler.go
+++ b/consumer_group_handler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
 )
 
@@ -16,7 +16,7 @@ type saramaCgHandler struct {
 
 // Setup is run by Sarama at the beginning of a new session, before ConsumeClaim.
 func (sh *saramaCgHandler) Setup(session sarama.ConsumerGroupSession) error {
-	log.Event(session.Context(), "sarama consumer group session setup ok: a new go-routine will be created for each partition assigned to this consumer", log.INFO, log.Data{"memberID": session.MemberID(), "claims": session.Claims()})
+	log.Info(session.Context(), "sarama consumer group session setup ok: a new go-routine will be created for each partition assigned to this consumer", log.Data{"memberID": session.MemberID(), "claims": session.Claims()})
 	select {
 	case <-sh.channels.Ready:
 	default:
@@ -27,7 +27,7 @@ func (sh *saramaCgHandler) Setup(session sarama.ConsumerGroupSession) error {
 
 // Cleanup is run by Sarama at the end of a session, once all ConsumeClaim goroutines have exited
 func (sh *saramaCgHandler) Cleanup(session sarama.ConsumerGroupSession) error {
-	log.Event(session.Context(), "sarama consumer group session cleanup finished: all go-routines have completed", log.INFO, log.Data{"memberID": session.MemberID(), "claims": session.Claims()})
+	log.Info(session.Context(), "sarama consumer group session cleanup finished: all go-routines have completed", log.Data{"memberID": session.MemberID(), "claims": session.Claims()})
 	return nil
 }
 

--- a/examples/consumer-batch/main.go
+++ b/examples/consumer-batch/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	kafka "github.com/ONSdigital/dp-kafka/v2"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -38,7 +38,7 @@ func main() {
 	ctx := context.Background()
 
 	if err := run(ctx); err != nil {
-		log.Event(ctx, "fatal runtime error", log.Error(err), log.FATAL)
+		log.Fatal(ctx, "fatal runtime error", err)
 		os.Exit(1)
 	}
 }
@@ -72,12 +72,12 @@ func run(ctx context.Context) error {
 
 	// blocks until an os interrupt or a fatal error occurs
 	sig := <-signals
-	log.Event(ctx, "os signal received", log.Data{"signal": sig}, log.INFO)
+	log.Info(ctx, "os signal received", log.Data{"signal": sig})
 	return closeConsumerGroup(ctx, consumerGroup, cfg.GracefulShutdownTimeout)
 }
 
 func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, error) {
-	log.Event(ctx, "[KAFKA-TEST] Starting ConsumerGroup (messages sent to stdout)", log.INFO, log.Data{"config": cfg})
+	log.Info(ctx, "[KAFKA-TEST] Starting ConsumerGroup (messages sent to stdout)", log.Data{"config": cfg})
 	kafka.SetMaxMessageSize(int32(cfg.KafkaMaxBytes))
 
 	// Create ConsumerGroup with channels and config
@@ -94,10 +94,10 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 	// Consumer not initialised at creation time. We need to retry to initialise it.
 	if !cg.IsInitialised() {
 		if cfg.WaitForConsumerReady {
-			log.Event(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Waiting until we can initialise it.", log.WARN)
+			log.Warn(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Waiting until we can initialise it.")
 			waitForInitialised(ctx, cg.Channels())
 		} else {
-			log.Event(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Will be initialised later.", log.WARN)
+			log.Warn(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Will be initialised later.")
 			go waitForInitialised(ctx, cg.Channels())
 		}
 	}
@@ -106,7 +106,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 	go func() {
 		for {
 			<-time.After(ticker)
-			log.Event(ctx, "[KAFKA-TEST] tick", log.INFO)
+			log.Info(ctx, "[KAFKA-TEST] tick")
 		}
 	}()
 
@@ -119,7 +119,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 // consume waits for messages to arrive to the upstream channel, appends them to a batch, and then, once the batch is full, processes the batch.
 // Note that the messages are released straight away, but not committed until the batch has been successfully processed.
 func consume(ctx context.Context, cfg *Config, upstream chan kafka.Message) {
-	log.Event(ctx, "started consuming")
+	log.Info(ctx, "started consuming")
 	var batch = []kafka.Message{}
 	for {
 		// get message from upstream channel
@@ -129,7 +129,7 @@ func consume(ctx context.Context, cfg *Config, upstream chan kafka.Message) {
 		}
 		consumeCount++
 		logData := log.Data{"consumeCount": consumeCount, "messageOffset": consumedMessage.Offset()}
-		log.Event(ctx, "[KAFKA-TEST] Received message", log.INFO, logData)
+		log.Info(ctx, "[KAFKA-TEST] Received message", logData)
 
 		// append message to batch
 		batch = append(batch, consumedMessage)
@@ -154,13 +154,13 @@ func processBatch(ctx context.Context, cfg *Config, logData log.Data, batch []ka
 	logData["batch_offsets"] = batchOffsets
 
 	// log before sleep
-	log.Event(ctx, "processing batch", log.INFO, logData)
+	log.Info(ctx, "processing batch", logData)
 
 	// Allows us to dictate the process for shutting down and how fast we consume messages in this example app, (should not be used in applications)
 	sleepIfRequired(ctx, cfg, logData)
 
 	// log after sleep
-	log.Event(ctx, "batch processed", log.INFO, logData)
+	log.Info(ctx, "batch processed", logData)
 
 	// commit after successfully
 	commitBatch(batch)
@@ -179,7 +179,7 @@ func commitBatch(batch []kafka.Message) {
 }
 
 func closeConsumerGroup(ctx context.Context, cg *kafka.ConsumerGroup, gracefulShutdownTimeout time.Duration) error {
-	log.Event(ctx, "commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": gracefulShutdownTimeout}, log.INFO)
+	log.Info(ctx, "commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": gracefulShutdownTimeout})
 	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 
 	// track shutown gracefully closes up
@@ -188,28 +188,28 @@ func closeConsumerGroup(ctx context.Context, cg *kafka.ConsumerGroup, gracefulSh
 	// background graceful shutdown
 	go func() {
 		defer cancel()
-		log.Event(ctx, "[KAFKA-TEST] Closing kafka consumerGroup", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] Closing kafka consumerGroup")
 		if err := cg.Close(ctx); err != nil {
 			hasShutdownError = true
 		}
-		log.Event(ctx, "[KAFKA-TEST] Closed kafka consumerGroup", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] Closed kafka consumerGroup")
 	}()
 
 	// wait for timeout or success (via cancel)
 	<-ctx.Done()
 
 	if ctx.Err() == context.DeadlineExceeded {
-		log.Event(ctx, "[KAFKA-TEST] graceful shutdown timed out", log.WARN, log.Error(ctx.Err()))
+		log.Warn(ctx, "[KAFKA-TEST] graceful shutdown timed out", log.FormatErrors([]error{ctx.Err()}))
 		return ctx.Err()
 	}
 
 	if hasShutdownError {
 		err := errors.New("failed to shutdown gracefully")
-		log.Event(ctx, "failed to shutdown gracefully ", log.ERROR, log.Error(err))
+		log.Error(ctx, "failed to shutdown gracefully ", err)
 		return err
 	}
 
-	log.Event(ctx, "graceful shutdown was successful", log.INFO)
+	log.Info(ctx, "graceful shutdown was successful")
 	return nil
 }
 
@@ -228,10 +228,10 @@ func sleepIfRequired(ctx context.Context, cfg *Config, logData log.Data) {
 		logData["sleep"] = sleep
 	}
 
-	log.Event(ctx, "[KAFKA-TEST] Message consumed", log.INFO, logData)
+	log.Info(ctx, "[KAFKA-TEST] Message consumed", logData)
 	if sleep > time.Duration(0) {
 		time.Sleep(sleep)
-		log.Event(ctx, "[KAFKA-TEST] done sleeping", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] done sleeping")
 	}
 }
 
@@ -239,8 +239,8 @@ func sleepIfRequired(ctx context.Context, cfg *Config, logData log.Data) {
 func waitForInitialised(ctx context.Context, cgChannels *kafka.ConsumerGroupChannels) {
 	select {
 	case <-cgChannels.Ready:
-		log.Event(ctx, "[KAFKA-TEST] Consumer is now initialised.", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer is now initialised.")
 	case <-cgChannels.Closer:
-		log.Event(ctx, "[KAFKA-TEST] Consumer is being closed.", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer is being closed.")
 	}
 }

--- a/examples/consumer-concurrent/main.go
+++ b/examples/consumer-concurrent/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	kafka "github.com/ONSdigital/dp-kafka/v2"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -38,7 +38,7 @@ func main() {
 	ctx := context.Background()
 
 	if err := run(ctx); err != nil {
-		log.Event(ctx, "fatal runtime error", log.Error(err), log.FATAL)
+		log.Fatal(ctx, "fatal runtime error", err)
 		os.Exit(1)
 	}
 }
@@ -72,12 +72,12 @@ func run(ctx context.Context) error {
 
 	// blocks until an os interrupt or a fatal error occurs
 	sig := <-signals
-	log.Event(ctx, "os signal received", log.Data{"signal": sig}, log.INFO)
+	log.Info(ctx, "os signal received", log.Data{"signal": sig})
 	return closeConsumerGroup(ctx, consumerGroup, cfg.GracefulShutdownTimeout)
 }
 
 func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, error) {
-	log.Event(ctx, "[KAFKA-TEST] Starting ConsumerGroup (messages sent to stdout)", log.INFO, log.Data{"config": cfg})
+	log.Info(ctx, "[KAFKA-TEST] Starting ConsumerGroup (messages sent to stdout)", log.Data{"config": cfg})
 	kafka.SetMaxMessageSize(int32(cfg.KafkaMaxBytes))
 
 	// Create ConsumerGroup with channels and config
@@ -94,10 +94,10 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 	// Consumer not initialised at creation time. We need to retry to initialise it.
 	if !cg.IsInitialised() {
 		if cfg.WaitForConsumerReady {
-			log.Event(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Waiting until we can initialise it.", log.WARN)
+			log.Warn(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Waiting until we can initialise it.")
 			waitForInitialised(ctx, cg.Channels())
 		} else {
-			log.Event(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Will be initialised later.", log.WARN)
+			log.Warn(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Will be initialised later.")
 			go waitForInitialised(ctx, cg.Channels())
 		}
 	}
@@ -106,7 +106,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 	go func() {
 		for {
 			<-time.After(ticker)
-			log.Event(ctx, "[KAFKA-TEST] tick", log.INFO)
+			log.Info(ctx, "[KAFKA-TEST] tick")
 		}
 	}()
 
@@ -120,7 +120,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 
 // consume waits for messages to arrive to the upstream channel and consumes them, in an infinite loop
 func consume(ctx context.Context, cfg *Config, id int, upstream chan kafka.Message) {
-	log.Event(ctx, "worker started consuming", log.Data{"worker_id": id})
+	log.Info(ctx, "worker started consuming", log.Data{"worker_id": id})
 	for {
 		consumedMessage, ok := <-upstream
 		if !ok {
@@ -128,7 +128,7 @@ func consume(ctx context.Context, cfg *Config, id int, upstream chan kafka.Messa
 		}
 		consumeCount++
 		logData := log.Data{"consumeCount": consumeCount, "messageOffset": consumedMessage.Offset(), "worker_id": id}
-		log.Event(ctx, "[KAFKA-TEST] Received message", log.INFO, logData)
+		log.Info(ctx, "[KAFKA-TEST] Received message", logData)
 
 		consumedData := consumedMessage.GetData()
 		logData["messageString"] = string(consumedData)
@@ -139,12 +139,12 @@ func consume(ctx context.Context, cfg *Config, id int, upstream chan kafka.Messa
 		sleepIfRequired(ctx, cfg, logData)
 
 		consumedMessage.CommitAndRelease()
-		log.Event(ctx, "[KAFKA-TEST] committed and released message", log.INFO, logData)
+		log.Info(ctx, "[KAFKA-TEST] committed and released message", logData)
 	}
 }
 
 func closeConsumerGroup(ctx context.Context, cg *kafka.ConsumerGroup, gracefulShutdownTimeout time.Duration) error {
-	log.Event(ctx, "commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": gracefulShutdownTimeout}, log.INFO)
+	log.Info(ctx, "commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": gracefulShutdownTimeout})
 	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 
 	// track shutown gracefully closes up
@@ -153,28 +153,28 @@ func closeConsumerGroup(ctx context.Context, cg *kafka.ConsumerGroup, gracefulSh
 	// background graceful shutdown
 	go func() {
 		defer cancel()
-		log.Event(ctx, "[KAFKA-TEST] Closing kafka consumerGroup", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] Closing kafka consumerGroup")
 		if err := cg.Close(ctx); err != nil {
 			hasShutdownError = true
 		}
-		log.Event(ctx, "[KAFKA-TEST] Closed kafka consumerGroup", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] Closed kafka consumerGroup")
 	}()
 
 	// wait for timeout or success (via cancel)
 	<-ctx.Done()
 
 	if ctx.Err() == context.DeadlineExceeded {
-		log.Event(ctx, "[KAFKA-TEST] graceful shutdown timed out", log.WARN, log.Error(ctx.Err()))
+		log.Warn(ctx, "[KAFKA-TEST] graceful shutdown timed out", log.FormatErrors([]error{ctx.Err()}))
 		return ctx.Err()
 	}
 
 	if hasShutdownError {
 		err := errors.New("failed to shutdown gracefully")
-		log.Event(ctx, "failed to shutdown gracefully ", log.ERROR, log.Error(err))
+		log.Error(ctx, "failed to shutdown gracefully ", err)
 		return err
 	}
 
-	log.Event(ctx, "graceful shutdown was successful", log.INFO)
+	log.Info(ctx, "graceful shutdown was successful")
 	return nil
 }
 
@@ -193,10 +193,10 @@ func sleepIfRequired(ctx context.Context, cfg *Config, logData log.Data) {
 		logData["sleep"] = sleep
 	}
 
-	log.Event(ctx, "[KAFKA-TEST] Message consumed", log.INFO, logData)
+	log.Info(ctx, "[KAFKA-TEST] Message consumed", logData)
 	if sleep > time.Duration(0) {
 		time.Sleep(sleep)
-		log.Event(ctx, "[KAFKA-TEST] done sleeping", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] done sleeping")
 	}
 }
 
@@ -204,8 +204,8 @@ func sleepIfRequired(ctx context.Context, cfg *Config, logData log.Data) {
 func waitForInitialised(ctx context.Context, cgChannels *kafka.ConsumerGroupChannels) {
 	select {
 	case <-cgChannels.Ready:
-		log.Event(ctx, "[KAFKA-TEST] Consumer is now initialised.", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer is now initialised.")
 	case <-cgChannels.Closer:
-		log.Event(ctx, "[KAFKA-TEST] Consumer is being closed.", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer is being closed.")
 	}
 }

--- a/examples/consumer-sequential/main.go
+++ b/examples/consumer-sequential/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	kafka "github.com/ONSdigital/dp-kafka/v2"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -40,7 +40,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if err := run(ctx, cancel); err != nil {
-		log.Event(ctx, "fatal runtime error", log.Error(err), log.FATAL)
+		log.Fatal(ctx, "fatal runtime error", err)
 		os.Exit(1)
 	}
 }
@@ -51,7 +51,7 @@ func run(ctx context.Context, cancel context.CancelFunc) error {
 	go func(cancel context.CancelFunc) {
 		// blocks until an os interrupt or a fatal error occurs
 		sig := <-signals
-		log.Event(ctx, "os signal received", log.Data{"signal": sig}, log.INFO)
+		log.Info(ctx, "os signal received", log.Data{"signal": sig})
 		cancel()
 	}(cancel)
 
@@ -82,7 +82,7 @@ func run(ctx context.Context, cancel context.CancelFunc) error {
 }
 
 func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, error) {
-	log.Event(ctx, "[KAFKA-TEST] Starting ConsumerGroup (messages sent to stdout)", log.INFO, log.Data{"config": cfg})
+	log.Info(ctx, "[KAFKA-TEST] Starting ConsumerGroup (messages sent to stdout)", log.Data{"config": cfg})
 	kafka.SetMaxMessageSize(int32(cfg.KafkaMaxBytes))
 
 	// Create ConsumerGroup with channels and config
@@ -109,10 +109,10 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 	// Consumer not initialised at creation time. We need to retry to initialise it.
 	if !cg.IsInitialised() {
 		if cfg.WaitForConsumerReady {
-			log.Event(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Waiting until we can initialise it.", log.WARN)
+			log.Warn(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Waiting until we can initialise it.")
 			waitForInitialised(ctx, cg.Channels())
 		} else {
-			log.Event(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Will be initialised later.", log.WARN)
+			log.Warn(ctx, "[KAFKA-TEST] Consumer could not be initialised at creation time. Will be initialised later.")
 			go waitForInitialised(ctx, cg.Channels())
 		}
 	}
@@ -124,7 +124,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 			select {
 
 			case <-time.After(ticker):
-				log.Event(ctx, "[KAFKA-TEST] tick", log.INFO)
+				log.Info(ctx, "[KAFKA-TEST] tick")
 
 			case consumedMessage, ok := <-cgChannels.Upstream:
 				if !ok {
@@ -133,7 +133,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 				// consumer will be nil if the broker could not be contacted, that's why we use the channel directly instead of consumer.Incoming()
 				consumeCount++
 				logData := log.Data{"consumeCount": consumeCount, "messageOffset": consumedMessage.Offset()}
-				log.Event(ctx, "[KAFKA-TEST] Received message", log.INFO, logData)
+				log.Info(ctx, "[KAFKA-TEST] Received message", logData)
 
 				consumedData := consumedMessage.GetData()
 				logData["messageString"] = string(consumedData)
@@ -144,7 +144,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 				sleepIfRequired(ctx, cfg, logData)
 
 				consumedMessage.CommitAndRelease()
-				log.Event(ctx, "[KAFKA-TEST] committed and released message", log.INFO, log.Data{"messageOffset": consumedMessage.Offset()})
+				log.Info(ctx, "[KAFKA-TEST] committed and released message", log.Data{"messageOffset": consumedMessage.Offset()})
 
 			case <-ctx.Done():
 				return
@@ -155,7 +155,7 @@ func runConsumerGroup(ctx context.Context, cfg *Config) (*kafka.ConsumerGroup, e
 }
 
 func closeConsumerGroup(ctx context.Context, cancel context.CancelFunc, cg *kafka.ConsumerGroup, gracefulShutdownTimeout time.Duration) (err error) {
-	log.Event(ctx, "commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": gracefulShutdownTimeout}, log.INFO)
+	log.Info(ctx, "commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": gracefulShutdownTimeout})
 	ctxShutdown, shutdownCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 
 	// track shutdown gracefully closes up
@@ -164,37 +164,37 @@ func closeConsumerGroup(ctx context.Context, cancel context.CancelFunc, cg *kafk
 	// background graceful shutdown
 	go func() {
 		defer shutdownCancel()
-		log.Event(ctx, "[KAFKA-TEST] Closing kafka consumerGroup", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] Closing kafka consumerGroup")
 		if err := cg.Close(ctxShutdown); err != nil {
 			shutdownError = err
 		}
-		log.Event(ctx, "[KAFKA-TEST] Closed kafka consumerGroup", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] Closed kafka consumerGroup")
 	}()
 
 	// wait for timeout or success (via cancel)
 	select {
 	case <-ctx.Done():
 		err = ctx.Err()
-		log.Event(ctx, "[KAFKA-TEST] graceful shutdown abandoned during close", log.WARN, log.Error(err))
+		log.Warn(ctx, "[KAFKA-TEST] graceful shutdown abandoned during close", log.FormatErrors([]error{err}))
 		return
 	case <-ctxShutdown.Done():
 		err = ctxShutdown.Err()
 		if err == context.DeadlineExceeded {
-			log.Event(ctx, "[KAFKA-TEST] graceful shutdown timed out", log.WARN, log.Error(err))
+			log.Warn(ctx, "[KAFKA-TEST] graceful shutdown timed out", log.FormatErrors([]error{err}))
 			return
 		} else if err != nil {
-			log.Event(ctx, "[KAFKA-TEST] graceful shutdown failed during close", log.ERROR, log.Error(err))
+			log.Error(ctx, "[KAFKA-TEST] graceful shutdown failed during close", err)
 			return
 		}
 
 		if shutdownError != nil {
 			err = fmt.Errorf("failed to shutdown gracefully: %w", shutdownError)
-			log.Event(ctx, "failed to shutdown gracefully ", log.ERROR, log.Error(err))
+			log.Error(ctx, "failed to shutdown gracefully ", err)
 			return
 		}
 	}
 
-	log.Event(ctx, "graceful shutdown was successful", log.INFO)
+	log.Info(ctx, "graceful shutdown was successful")
 	return
 }
 
@@ -213,10 +213,10 @@ func sleepIfRequired(ctx context.Context, cfg *Config, logData log.Data) {
 		logData["sleep"] = sleep
 	}
 
-	log.Event(ctx, "[KAFKA-TEST] Message consumed", log.INFO, logData)
+	log.Info(ctx, "[KAFKA-TEST] Message consumed", logData)
 	if sleep > time.Duration(0) {
 		time.Sleep(sleep)
-		log.Event(ctx, "[KAFKA-TEST] done sleeping", log.INFO)
+		log.Info(ctx, "[KAFKA-TEST] done sleeping")
 	}
 }
 
@@ -224,10 +224,10 @@ func sleepIfRequired(ctx context.Context, cfg *Config, logData log.Data) {
 func waitForInitialised(ctx context.Context, cgChannels *kafka.ConsumerGroupChannels) {
 	select {
 	case <-cgChannels.Ready:
-		log.Event(ctx, "[KAFKA-TEST] Consumer is now initialised.", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer is now initialised.")
 	case <-cgChannels.Closer:
-		log.Event(ctx, "[KAFKA-TEST] Consumer is being closed.", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer is being closed.")
 	case <-ctx.Done():
-		log.Event(ctx, "[KAFKA-TEST] Consumer context done - not waiting for initialisation", log.WARN)
+		log.Warn(ctx, "[KAFKA-TEST] Consumer context done - not waiting for initialisation")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.40.0 // indirect
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/log.go v1.0.1
+	github.com/ONSdigital/log.go/v2 v2.0.5
 	github.com/Shopify/sarama v1.29.1
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/go-avro/avro v0.0.0-20171219232920-444163702c11

--- a/go.sum
+++ b/go.sum
@@ -17,7 +17,10 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/ONSdigital/log.go/v2 v2.0.0 h1:ozm2DORFnPwVe1Dmved7ccjNo16z06EOmAXAllZxW3A=
 github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
+github.com/ONSdigital/log.go/v2 v2.0.5 h1:kl2lF0vr3BQDwPTAUcarDvX4Um3uE3fjVRfLoHAarBc=
+github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/Shopify/sarama v1.29.1 h1:wBAacXbYVLmWieEA/0X/JagDdCZ8NVFOfS6l6+2u5S0=
 github.com/Shopify/sarama v1.29.1/go.mod h1:mdtqvCSg8JOxk8PmpTNGyo6wzd4BMm4QXSfDnTXmgkE=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
 )
 
@@ -59,7 +59,7 @@ func (p *Producer) healthcheck(ctx context.Context) error {
 	// If Sarama client is not initialised, we need to initialise it
 	err = p.Initialise(ctx)
 	if err != nil {
-		log.Event(ctx, "error initialising sarama producer", log.WARN, log.Data{"topic": p.topic}, log.Error(err))
+		log.Warn(ctx, "error initialising sarama producer", log.Data{"topic": p.topic}, log.FormatErrors([]error{err}))
 		return ErrInitSarama
 	}
 	return nil
@@ -74,7 +74,7 @@ func (cg *ConsumerGroup) healthcheck(ctx context.Context) error {
 	// If Sarama client is not initialised, we need to initialise it
 	err = cg.Initialise(ctx)
 	if err != nil {
-		log.Event(ctx, "error initialising sarama consumer-group", log.WARN, log.Data{"topic": cg.topic, "group": cg.group}, log.Error(err))
+		log.Warn(ctx, "error initialising sarama consumer-group", log.Data{"topic": cg.topic, "group": cg.group}, log.FormatErrors([]error{err}))
 		return ErrInitSarama
 	}
 	return nil
@@ -126,10 +126,10 @@ func validateBroker(ctx context.Context, broker *sarama.Broker, topic string, cf
 
 	// try to open connection if it is not connected
 	if !isConnected {
-		log.Event(ctx, "broker not connected. Trying to open connection now", log.INFO, log.Data{"address": broker.Addr()})
+		log.Info(ctx, "broker not connected. Trying to open connection now", log.Data{"address": broker.Addr()})
 		err := broker.Open(cfg)
 		if err != nil {
-			log.Event(ctx, "failed to open connection with broker", log.WARN, log.Data{"address": broker.Addr()}, log.Error(err))
+			log.Warn(ctx, "failed to open connection with broker", log.Data{"address": broker.Addr()}, log.FormatErrors([]error{err}))
 			return false, false
 		}
 	}
@@ -138,7 +138,7 @@ func validateBroker(ctx context.Context, broker *sarama.Broker, topic string, cf
 	request := sarama.MetadataRequest{Topics: []string{topic}}
 	resp, err := broker.GetMetadata(&request)
 	if err != nil {
-		log.Event(ctx, "failed to obtain metadata from broker", log.WARN, log.Data{"address": broker.Addr(), "topic": topic}, log.Error(err))
+		log.Warn(ctx, "failed to obtain metadata from broker", log.Data{"address": broker.Addr(), "topic": topic}, log.FormatErrors([]error{err}))
 		return false, false
 	}
 

--- a/producer.go
+++ b/producer.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
 	"github.com/rcrowley/go-metrics"
 )
@@ -128,7 +128,7 @@ func (p *Producer) Initialise(ctx context.Context) error {
 
 	// On Successful initialization, close Init channel to stop uninitialised goroutine, and create initialised goroutine
 	p.producer = saramaProducer
-	log.Event(ctx, "initialised sarama producer", log.INFO, log.Data{"topic": p.topic})
+	log.Info(ctx, "initialised sarama producer", log.Data{"topic": p.topic})
 	p.createLoopInitialised(ctx)
 	close(p.channels.Ready)
 	return nil
@@ -148,7 +148,7 @@ func (p *Producer) Close(ctx context.Context) (err error) {
 
 	didTimeout := waitWithTimeout(ctx, p.wgClose)
 	if didTimeout {
-		log.Event(ctx, "shutdown context time exceeded, skipping graceful shutdown of producer", log.WARN)
+		log.Warn(ctx, "shutdown context time exceeded, skipping graceful shutdown of producer")
 		return ErrShutdownTimedOut
 	}
 
@@ -160,7 +160,7 @@ func (p *Producer) Close(ctx context.Context) (err error) {
 	// Close producer only if it was initialised
 	if p.IsInitialised() {
 		if err = p.producer.Close(); err != nil {
-			log.Event(ctx, "close failed of kafka producer", log.ERROR, log.Error(err), logData)
+			log.Error(ctx, "close failed of kafka producer", err, logData)
 			return err
 		}
 	}
@@ -170,7 +170,7 @@ func (p *Producer) Close(ctx context.Context) (err error) {
 		broker.Close()
 	}
 
-	log.Event(ctx, "successfully closed kafka producer", log.INFO, logData)
+	log.Info(ctx, "successfully closed kafka producer", logData)
 	close(p.channels.Closed)
 	return nil
 }
@@ -193,22 +193,22 @@ func (p *Producer) createLoopUninitialised(ctx context.Context) {
 		for {
 			select {
 			case message := <-p.channels.Output:
-				log.Event(ctx, "error sending a message", log.INFO, log.Data{"message": message, "topic": p.topic}, log.Error(ErrUninitialisedProducer))
+				log.Info(ctx, "error sending a message", log.Data{"message": message, "topic": p.topic}, log.FormatErrors([]error{ErrUninitialisedProducer}))
 				p.channels.Errors <- ErrUninitialisedProducer
 			case <-p.channels.Ready:
 				return
 			case <-p.channels.Closer:
-				log.Event(ctx, "closing uninitialised kafka producer", log.INFO, log.Data{"topic": p.topic})
+				log.Info(ctx, "closing uninitialised kafka producer", log.Data{"topic": p.topic})
 				return
 			case <-time.After(getRetryTime(initAttempt, InitRetryPeriod)):
 				if err := p.Initialise(ctx); err != nil {
-					log.Event(ctx, "error initialising producer", log.ERROR, log.Error(err), log.Data{"attempt": initAttempt})
+					log.Error(ctx, "error initialising producer", err, log.Data{"attempt": initAttempt})
 					initAttempt++
 					continue
 				}
 				return
 			case <-ctx.Done():
-				log.Event(ctx, "abandoning uninitialised producer - context expired", log.ERROR, log.Error(ctx.Err()), log.Data{"attempt": initAttempt})
+				log.Error(ctx, "abandoning uninitialised producer - context expired", ctx.Err(), log.Data{"attempt": initAttempt})
 				return
 			}
 		}
@@ -237,7 +237,7 @@ func (p *Producer) createLoopInitialised(ctx context.Context) error {
 			case message := <-p.channels.Output:
 				p.producer.Input() <- &sarama.ProducerMessage{Topic: p.topic, Value: sarama.StringEncoder(message)}
 			case <-p.channels.Closer:
-				log.Event(ctx, "closing initialised kafka producer", log.INFO, log.Data{"topic": p.topic})
+				log.Info(ctx, "closing initialised kafka producer", log.Data{"topic": p.topic})
 				return
 			}
 		}


### PR DESCRIPTION

### What
Update logging statements to format that can be parsed by
elastisearch, e.g.

log.Event(ctx, string, log.FATAL, log.Error(something1), something2)
-> log.Fatal(ctx, string, something1, something2)
log.Event(ctx, string, log.ERROR log.Error(something1), something2)
-> log.Error(ctx, string, something1, something2)
log.Event(ctx, string, log.INFO, log.Error(something))
-> log.Info(ctx, string, log.FormatErrors([]error{something}))
log.Event(ctx, string, log.WARN, log.Error(something))
-> log.Warn(ctx, string, log.FormatErrors([]error{something}))

These changes needed to allow error logs to be properly viewed in
kibana.

### How to review

Run make test
Inspect for obvious errors

### Who can review

Anyone
