### PR TITLE
fix to retry time (add max retry interval); improve health check reconnect

### DIFF
--- a/global_test.go
+++ b/global_test.go
@@ -1,0 +1,53 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetRetryTime(t *testing.T) {
+
+	Convey("Given a valid retry interval", t, func() {
+
+		var initialInterval_ms int64 = 200
+		initialInterval := time.Duration(initialInterval_ms) * time.Millisecond
+
+		Convey("getRetryTime returns sane progression over many attempts", func() {
+			maxInterval_ms := MaxRetryInterval.Milliseconds()
+			expectedInterval := initialInterval
+			powerHasWrapped := false
+
+			for attempt := 1; attempt < 100; attempt++ {
+				// get computed interval
+				interval := getRetryTime(attempt, initialInterval)
+				interval_ms := interval.Milliseconds()
+
+				expectedInterval_ms := expectedInterval.Milliseconds()
+
+				So(interval_ms, ShouldBeGreaterThanOrEqualTo, initialInterval_ms/100*75)
+				if powerHasWrapped {
+					So(interval_ms, ShouldBeGreaterThan, maxInterval_ms-initialInterval_ms)
+				} else {
+					// when values have not wrapped/overflowed
+					possiblyOverInterval := expectedInterval_ms + initialInterval_ms
+					if possiblyOverInterval < MaxRetryInterval.Milliseconds() {
+						// and not over MaxRetryInterval yet
+						So(interval_ms, ShouldBeBetween,
+							expectedInterval_ms-initialInterval_ms,
+							expectedInterval_ms+initialInterval_ms)
+					}
+
+				}
+				So(interval_ms, ShouldBeLessThan, maxInterval_ms+initialInterval_ms)
+
+				expectedInterval *= 2
+				if expectedInterval <= 0 {
+					powerHasWrapped = true
+				}
+			}
+		})
+	})
+
+}

--- a/go.sum
+++ b/go.sum
@@ -17,7 +17,6 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
-github.com/ONSdigital/log.go/v2 v2.0.0 h1:ozm2DORFnPwVe1Dmved7ccjNo16z06EOmAXAllZxW3A=
 github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/ONSdigital/log.go/v2 v2.0.5 h1:kl2lF0vr3BQDwPTAUcarDvX4Um3uE3fjVRfLoHAarBc=
 github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=


### PR DESCRIPTION
### What

1. 💚 the consumer/producer reconnect when kafka becomes available again
1. :warning: the health-checker didn't recover
1. 💚 the health-checker checks every ~30s (so no backoff issues here)
1. :warning: the backoff (for 1, above) doubles indefinitely (i.e. quickly to infinity/overflow) - so I have added a configurable maximum retry time (default 31s)

this PR addresses 2 and 4, above.

### How to review

use the lib in an app, restart kafka

### Who can review

!gedge
