### PR TITLE
downgrade healthcheck to v1

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ONSdigital/dp-healthcheck/v2/healthcheck"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
 	"github.com/rcrowley/go-metrics"

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ONSdigital/dp-healthcheck/v2/healthcheck"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-kafka/v3/mock"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-kafka/v3
 go 1.17
 
 require (
-	github.com/ONSdigital/dp-healthcheck/v2 v2.0.0-beta
+	github.com/ONSdigital/dp-healthcheck v1.2.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/Shopify/sarama v1.29.1
 	github.com/fatih/color v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ONSdigital/dp-healthcheck/v2 v2.0.0-beta h1:7QtVj7jPO/awVyUTSlLcdpnjOFu1512MH9l/zNMWk2A=
-github.com/ONSdigital/dp-healthcheck/v2 v2.0.0-beta/go.mod h1:cJJj1f3LEqXTzUzOfxQlLWrUXgEF3LZ1fdagPogjRTw=
+github.com/ONSdigital/dp-healthcheck v1.2.0 h1:k7okbVff7PW/393FxEvSdZ+FbZgaWRMJYKquqnkgDp8=
+github.com/ONSdigital/dp-healthcheck v1.2.0/go.mod h1:XUhXoDIWPCdletDtpDOoXhmDFcc9b/kbedx96jN75aI=
 github.com/ONSdigital/log.go/v2 v2.0.9 h1:dMtuN89vCP21iRuOBAGInn7ZzxIEGajC3o5pjoicnsY=
 github.com/ONSdigital/log.go/v2 v2.0.9/go.mod h1:VyTDkL82FtiAkaNFaT+bURBhLbP7NsIx4rkVbdpiuEg=
 github.com/Shopify/sarama v1.29.1 h1:wBAacXbYVLmWieEA/0X/JagDdCZ8NVFOfS6l6+2u5S0=

--- a/kafkatest/mock_consumer_group.go
+++ b/kafkatest/mock_consumer_group.go
@@ -5,7 +5,7 @@ package kafkatest
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-healthcheck/v2/healthcheck"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-kafka/v3"
 	"sync"
 )

--- a/kafkatest/mock_producer.go
+++ b/kafkatest/mock_producer.go
@@ -5,7 +5,7 @@ package kafkatest
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-healthcheck/v2/healthcheck"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-kafka/v3"
 	"github.com/ONSdigital/dp-kafka/v3/avro"
 	"sync"

--- a/producer.go
+++ b/producer.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ONSdigital/dp-healthcheck/v2/healthcheck"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-kafka/v3/avro"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"

--- a/producer_test.go
+++ b/producer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ONSdigital/dp-healthcheck/v2/healthcheck"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/dp-kafka/v3/mock"
 	"github.com/Shopify/sarama"
 	. "github.com/smartystreets/goconvey/convey"


### PR DESCRIPTION
### What

- Downgraded `dp-healthcheck` dependency to version 1.2.0, because version 2 was deleted

### How to review

- Make sure dependency changes make sense (no functional change)
- Make sure unit tests and audit pass
- Make sure `go mod tidy` doesn't produce any change in `go.mod` or `go.sum`

### Who can review

Anyone
