### PR TITLE
Fix context usage and add Channels for state changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	go test -v -count=1 -race -cover ./...
+	go test -count=1 -race -cover ./...
 .PHONY: test
 
 audit:

--- a/channels.go
+++ b/channels.go
@@ -26,6 +26,17 @@ type ConsumerGroupChannels struct {
 	Consume     chan bool
 	Closer      chan struct{}
 	Closed      chan struct{}
+	State       *ConsumerStateChannels
+}
+
+// ConsumerStateChannels represents the channels that are used to notify of consumer-group state changes
+type ConsumerStateChannels struct {
+	Initialising chan struct{}
+	Stopped      chan struct{}
+	Starting     chan struct{}
+	Consuming    chan struct{}
+	Stopping     chan struct{}
+	Closing      chan struct{}
 }
 
 // ProducerChannels represents the channels used by Producer.
@@ -40,6 +51,7 @@ type ProducerChannels struct {
 // CreateConsumerGroupChannels initialises a ConsumerGroupChannels with new channels.
 // You can provide the buffer size to determine the number of messages that will be buffered
 // in the upstream channel (to receive messages)
+// The State channels are not initialised until the state machine is created.
 func CreateConsumerGroupChannels(bufferSize int) *ConsumerGroupChannels {
 	var chUpstream chan Message
 	if bufferSize > 0 {

--- a/channels.go
+++ b/channels.go
@@ -2,8 +2,10 @@ package kafka
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/Shopify/sarama"
 )
 
 // channel names
@@ -196,5 +198,49 @@ func SafeCloseErr(ch chan error) (justClosed bool) {
 	}()
 	close(ch)
 	justClosed = true
+	return
+}
+
+// SafeSendBool sends a provided bool value to the provided bool chan and returns an error instead of panicking if the channel is closed
+func SafeSendBool(ch chan bool, val bool) (err error) {
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			err = fmt.Errorf("failed to send bool value to channel: %v", pErr)
+		}
+	}()
+	ch <- val
+	return
+}
+
+// SafeSendProducerMessage sends a provided ProducerMessage value to the provided ProducerMessage chan and returns an error instad of panicking if the channel is closed
+func SafeSendProducerMessage(ch chan<- *sarama.ProducerMessage, val *sarama.ProducerMessage) (err error) {
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			err = fmt.Errorf("failed to send ProducerMessage value to channel: %v", pErr)
+		}
+	}()
+	ch <- val
+	return
+}
+
+// SafeSendBytes sends a provided byte array value to the provided byte array chan and returns an error instead of panicking if the channel is closed
+func SafeSendBytes(ch chan []byte, val []byte) (err error) {
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			err = fmt.Errorf("failed to send byte array value to channel: %v", pErr)
+		}
+	}()
+	ch <- val
+	return
+}
+
+// SafeSendErr sends a provided error value to the provided error chan and returns an error instead of panicking if the channel is closed
+func SafeSendErr(ch chan error, val error) (err error) {
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			err = fmt.Errorf("failed to send err value to channel: %v", pErr)
+		}
+	}()
+	ch <- val
 	return
 }

--- a/channels.go
+++ b/channels.go
@@ -138,3 +138,63 @@ func (producerChannels *ProducerChannels) Validate() error {
 	}
 	return nil
 }
+
+// SafeClose closes a struct{} channel and ignores the panic if the channel was already closed
+func SafeClose(ch chan struct{}) (justClosed bool) {
+	defer func() {
+		if recover() != nil {
+			justClosed = false
+		}
+	}()
+	close(ch)
+	justClosed = true
+	return
+}
+
+// SafeCloseMessage closes a Message channel and ignores the panic if the channel was already closed
+func SafeCloseMessage(ch chan Message) (justClosed bool) {
+	defer func() {
+		if recover() != nil {
+			justClosed = false
+		}
+	}()
+	close(ch)
+	justClosed = true
+	return
+}
+
+// SafeCloseBytes closes a byte array channel and ignores the panic if the channel was already closed
+func SafeCloseBytes(ch chan []byte) (justClosed bool) {
+	defer func() {
+		if recover() != nil {
+			justClosed = false
+		}
+	}()
+	close(ch)
+	justClosed = true
+	return
+}
+
+// SafeCloseBool closes a bool channel and ignores the panic if the channel was already closed
+func SafeCloseBool(ch chan bool) (justClosed bool) {
+	defer func() {
+		if recover() != nil {
+			justClosed = false
+		}
+	}()
+	close(ch)
+	justClosed = true
+	return
+}
+
+// SafeCloseErr closes an error channel and ignores the panic if the channel was already closed
+func SafeCloseErr(ch chan error) (justClosed bool) {
+	defer func() {
+		if recover() != nil {
+			justClosed = false
+		}
+	}()
+	close(ch)
+	justClosed = true
+	return
+}

--- a/channels_test.go
+++ b/channels_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/ONSdigital/log.go/v2/log"
 	. "github.com/smartystreets/goconvey/convey"
@@ -250,4 +251,131 @@ func TestConsumerGroupChannelsValidate(t *testing.T) {
 			))
 		})
 	})
+}
+
+func TestSafeClose(t *testing.T) {
+	Convey("A struct channel can be safely closed and closing it again does not panic", t, func(c C) {
+		ch := make(chan struct{})
+		So(SafeClose(ch), ShouldBeTrue)
+		validateChanClosed(c, ch, true)
+		So(SafeClose(ch), ShouldBeFalse)
+	})
+
+	Convey("A bool channel can be safely closed and closing it again does not panic", t, func(c C) {
+		ch := make(chan bool)
+		So(SafeCloseBool(ch), ShouldBeTrue)
+		validateChanBoolClosed(c, ch, true)
+		So(SafeCloseBool(ch), ShouldBeFalse)
+	})
+
+	Convey("A Message channel can be safely closed and closing it again does not panic", t, func(c C) {
+		ch := make(chan Message)
+		So(SafeCloseMessage(ch), ShouldBeTrue)
+		validateChanMessageClosed(c, ch, true)
+		So(SafeCloseMessage(ch), ShouldBeFalse)
+	})
+
+	Convey("An Error channel can be safely closed and closing it again does not panic", t, func(c C) {
+		ch := make(chan error)
+		So(SafeCloseErr(ch), ShouldBeTrue)
+		validateChanErrClosed(c, ch, true)
+		So(SafeCloseErr(ch), ShouldBeFalse)
+	})
+
+	Convey("A byte array channel can be safely closed and closing it again does not panic", t, func(c C) {
+		ch := make(chan []byte)
+		So(SafeCloseBytes(ch), ShouldBeTrue)
+		validateChanBytesClosed(c, ch, true)
+		So(SafeCloseBytes(ch), ShouldBeFalse)
+	})
+}
+
+// validateChanClosed validates that a struct channel is closed before a timeout expires
+func validateChanClosed(c C, ch chan struct{}, expectedClosed bool) {
+	var (
+		closed  bool
+		timeout bool
+	)
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			closed = true
+		}
+	case <-time.After(TIMEOUT):
+		timeout = true
+	}
+	c.So(timeout, ShouldNotEqual, expectedClosed)
+	c.So(closed, ShouldEqual, expectedClosed)
+}
+
+// validateChanBoolClosed validates that a boolean channel is closed before a timeout expires
+func validateChanBoolClosed(c C, ch chan bool, expectedClosed bool) {
+	var (
+		closed  bool
+		timeout bool
+	)
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			closed = true
+		}
+	case <-time.After(TIMEOUT):
+		timeout = true
+	}
+	c.So(timeout, ShouldNotEqual, expectedClosed)
+	c.So(closed, ShouldEqual, expectedClosed)
+}
+
+// validateChanMessageClosed validates that a Message channel is closed before a timeout expires
+func validateChanMessageClosed(c C, ch chan Message, expectedClosed bool) {
+	var (
+		closed  bool
+		timeout bool
+	)
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			closed = true
+		}
+	case <-time.After(TIMEOUT):
+		timeout = true
+	}
+	c.So(timeout, ShouldNotEqual, expectedClosed)
+	c.So(closed, ShouldEqual, expectedClosed)
+}
+
+// validateChanBytesClosed validates that a byte array  channel is closed before a timeout expires
+func validateChanBytesClosed(c C, ch chan []byte, expectedClosed bool) {
+	var (
+		closed  bool
+		timeout bool
+	)
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			closed = true
+		}
+	case <-time.After(TIMEOUT):
+		timeout = true
+	}
+	c.So(timeout, ShouldNotEqual, expectedClosed)
+	c.So(closed, ShouldEqual, expectedClosed)
+}
+
+// validateChanMessageClosed validates that an Error channel is closed before a timeout expires
+func validateChanErrClosed(c C, ch chan error, expectedClosed bool) {
+	var (
+		closed  bool
+		timeout bool
+	)
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			closed = true
+		}
+	case <-time.After(TIMEOUT):
+		timeout = true
+	}
+	c.So(timeout, ShouldNotEqual, expectedClosed)
+	c.So(closed, ShouldEqual, expectedClosed)
 }

--- a/config_consumer_test.go
+++ b/config_consumer_test.go
@@ -38,6 +38,8 @@ func TestConsumerGroupConfig(t *testing.T) {
 				So(*cgConfig.NumWorkers, ShouldEqual, defaultNumWorkers)
 				So(*cgConfig.BatchSize, ShouldEqual, defaultBatchSize)
 				So(*cgConfig.BatchWaitTime, ShouldEqual, defaultBatchWaitTime)
+				So(*cgConfig.MinRetryPeriod, ShouldEqual, defaultMinRetryPeriod)
+				So(*cgConfig.MaxRetryPeriod, ShouldEqual, defaultMaxRetryPeriod)
 			})
 		})
 
@@ -58,6 +60,8 @@ func TestConsumerGroupConfig(t *testing.T) {
 				NumWorkers:       &numWorkers,
 				BatchSize:        &batchSize,
 				BatchWaitTime:    &batchWaitTime,
+				MinRetryPeriod:   &testMinRetryPeriod,
+				MaxRetryPeriod:   &testMaxRetryPeriod,
 			}
 			config, err := cgConfig.Get()
 			So(err, ShouldBeNil)
@@ -73,12 +77,13 @@ func TestConsumerGroupConfig(t *testing.T) {
 			So(config.Net.TLS.Enable, ShouldBeTrue)
 			So(config.Net.TLS.Config.InsecureSkipVerify, ShouldBeFalse)
 
-			Convey("And the default values are set for the non-kafka configuration", func() {
+			Convey("And the values are overwritten for the non-kafka configuration", func() {
 				So(*cgConfig.NumWorkers, ShouldEqual, numWorkers)
 				So(*cgConfig.BatchSize, ShouldEqual, batchSize)
 				So(*cgConfig.BatchWaitTime, ShouldEqual, batchWaitTime)
+				So(*cgConfig.MinRetryPeriod, ShouldEqual, testMinRetryPeriod)
+				So(*cgConfig.MaxRetryPeriod, ShouldEqual, testMaxRetryPeriod)
 			})
-
 		})
 
 		Convey("getConsumerGroupConfig with consumerGroupConfig containing an invalid kafka version returns the expected error", func() {
@@ -105,6 +110,64 @@ func TestConsumerGroupConfig(t *testing.T) {
 			config, err := cgConfig.Get()
 			So(err, ShouldResemble, errors.New("offset value incorrect"))
 			So(config, ShouldBeNil)
+		})
+	})
+}
+
+func TestConsumerGroupConfigValidation(t *testing.T) {
+	Convey("Given a consumer group config", t, func() {
+		cfg := ConsumerGroupConfig{
+			Topic:          testTopic,
+			GroupName:      testGroupName,
+			BrokerAddrs:    testBrokerAddrs,
+			MinRetryPeriod: &testMinRetryPeriod,
+			MaxRetryPeriod: &testMaxRetryPeriod,
+		}
+
+		Convey("With all values being valid, then Validate does not return an error", func() {
+			err := cfg.Validate()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("With an empty topic value, then Validate fails with the expected error", func() {
+			cfg.Topic = ""
+			err := cfg.Validate()
+			So(err, ShouldResemble, errors.New("topic is compulsory but was not provided in config"))
+		})
+
+		Convey("With an empty groupName value, then Validate fails with the expected error", func() {
+			cfg.GroupName = ""
+			err := cfg.Validate()
+			So(err, ShouldResemble, errors.New("groupName is compulsory but was not provided in config"))
+		})
+
+		Convey("With an empty array of broker addrs, then Validate fails with the expected error", func() {
+			cfg.BrokerAddrs = []string{}
+			err := cfg.Validate()
+			So(err, ShouldResemble, errors.New("brokerAddrs is compulsory but was not provided in config"))
+		})
+
+		Convey("With a zero value for MinRetryPeriod, then Validate fails with the expected error", func() {
+			var minRetryPeriod time.Duration = 0
+			cfg.MinRetryPeriod = &minRetryPeriod
+			err := cfg.Validate()
+			So(err, ShouldResemble, errors.New("minRetryPeriod must be greater than zero"))
+		})
+
+		Convey("With a zero value for MaxRetryPeriod, then Validate fails with the expected error", func() {
+			var maxRetryPeriod time.Duration = 0
+			cfg.MaxRetryPeriod = &maxRetryPeriod
+			err := cfg.Validate()
+			So(err, ShouldResemble, errors.New("maxRetryPeriod must be greater than zero"))
+		})
+
+		Convey("With MinRetryPeriod greater than MaxRetryPeriod, then Validate fails with the expected error", func() {
+			var minRetryPeriod time.Duration = 1001 * time.Millisecond
+			var maxRetryPeriod time.Duration = time.Second
+			cfg.MinRetryPeriod = &minRetryPeriod
+			cfg.MaxRetryPeriod = &maxRetryPeriod
+			err := cfg.Validate()
+			So(err, ShouldResemble, errors.New("minRetryPeriod must be smaller or equal to maxRetryPeriod"))
 		})
 	})
 }

--- a/config_test.go
+++ b/config_test.go
@@ -15,4 +15,6 @@ var (
 	testOffsetNewest             = OffsetNewest
 	testGroupName                = "someGroupName"
 	testBrokerAddrs              = []string{"kafka:9092", "kafka:9093", "kafka:9094"}
+	testMinRetryPeriod           = 100 * time.Millisecond
+	testMaxRetryPeriod           = 45 * time.Second
 )

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -76,14 +76,18 @@ func newConsumerGroup(ctx context.Context, cgConfig *ConsumerGroupConfig, cgInit
 		upstreamBufferSize = *cgConfig.BatchSize
 	}
 
+	channels := CreateConsumerGroupChannels(upstreamBufferSize)
+	stateMachine := NewConsumerStateMachine()
+	channels.State = stateMachine.channels
+
 	// ConsumerGroup created with provided brokerAddrs, topic, group and sync
 	cg := &ConsumerGroup{
 		brokerAddrs:   cgConfig.BrokerAddrs,
 		brokers:       []SaramaBroker{},
-		channels:      CreateConsumerGroupChannels(upstreamBufferSize),
+		channels:      channels,
 		topic:         cgConfig.Topic,
 		group:         cgConfig.GroupName,
-		state:         NewConsumerStateMachine(Initialising),
+		state:         stateMachine,
 		initialState:  Stopped,
 		saramaConfig:  cfg,
 		mutex:         &sync.Mutex{},

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -372,7 +372,7 @@ func (cg *ConsumerGroup) Close(ctx context.Context) (err error) {
 
 // createLoopUninitialised creates a goroutine to handle uninitialised consumer groups.
 // It retries to initialise the consumer with an exponential backoff retrial algorithm,
-// starting with 'InitRetryPeriod' and restarted when MaxRetryInterval is reached.
+// starting with 'minRetryPeriod' and restarted when 'maxRetryPeriod' is reached.
 func (cg *ConsumerGroup) createLoopUninitialised(ctx context.Context) {
 	if cg.IsInitialised() {
 		return // do nothing if consumer group already initialised
@@ -441,8 +441,8 @@ func (cg *ConsumerGroup) stoppedState(ctx context.Context, logData log.Data) {
 // before calling consume again after a session finishes, we check if one of the following events has happened:
 // - A 'false' value is received from the Consume channel: the state is set to 'Stopping' and the func will return
 // - The Closer channel or the Consume channel is closed: the state is set to 'Closing' and the func will return
-// If saramaCg.Consume fails, we retry after an initial period of InitRetryPeriod,
-// following an exponential backoff between retries, until MaxRetryInterval is reached, at which point the retry algorithm is restarted.
+// If saramaCg.Consume fails, we retry after an initial period of 'minRetryPeriod',
+// following an exponential backoff between retries, until 'maxRetryPeriod' is reached, at which point the retry algorithm is restarted.
 // If the consumer changes its state between retries, we abort the loop as described above.
 func (cg *ConsumerGroup) startingState(ctx context.Context, logData log.Data) {
 	cg.state.Set(Starting)

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -134,7 +134,6 @@ func TestConsumerInitialised(t *testing.T) {
 }
 
 func TestConsumerNotInitialised(t *testing.T) {
-
 	Convey("Given that Sarama-cluster fails to create a new Consumer while we initialise our ConsumerGroup", t, func(c C) {
 		cgInitCalls := 0
 		cgInit := func(addrs []string, groupID string, config *sarama.Config) (sarama.ConsumerGroup, error) {
@@ -741,11 +740,13 @@ func TestConsumerStarting(t *testing.T) {
 		channels := CreateConsumerGroupChannels(1)
 		chConsumeCalled := make(chan struct{})
 		cg := &ConsumerGroup{
-			state:    NewConsumerStateMachine(),
-			channels: channels,
-			saramaCg: saramaConsumerGroupConsumeFails(chConsumeCalled),
-			mutex:    &sync.Mutex{},
-			wgClose:  &sync.WaitGroup{},
+			state:          NewConsumerStateMachine(),
+			channels:       channels,
+			saramaCg:       saramaConsumerGroupConsumeFails(chConsumeCalled),
+			mutex:          &sync.Mutex{},
+			wgClose:        &sync.WaitGroup{},
+			minRetryPeriod: defaultMinRetryPeriod,
+			maxRetryPeriod: defaultMaxRetryPeriod,
 		}
 		cg.state.Set(Starting)
 		wg := &sync.WaitGroup{}
@@ -852,10 +853,12 @@ func TestCreateLoopUninitialised(t *testing.T) {
 	Convey("Given a consumer group in Initialising state", t, func() {
 		channels := CreateConsumerGroupChannels(1)
 		cg := &ConsumerGroup{
-			state:    NewConsumerStateMachine(),
-			channels: channels,
-			mutex:    &sync.Mutex{},
-			wgClose:  &sync.WaitGroup{},
+			state:          NewConsumerStateMachine(),
+			channels:       channels,
+			mutex:          &sync.Mutex{},
+			wgClose:        &sync.WaitGroup{},
+			minRetryPeriod: defaultMinRetryPeriod,
+			maxRetryPeriod: defaultMaxRetryPeriod,
 		}
 
 		Convey("Where createLoopUninitialised is called", func() {

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -558,12 +558,12 @@ func TestOnHealthUpdate(t *testing.T) {
 			So(cg.initialState, ShouldEqual, Starting)
 		})
 
-		Convey("When a notification of an 'WARNING' health status is received, then the consumer-group is started", func() {
+		Convey("When a notification of an 'WARNING' health status is received, then the consumer-group is stopped", func() {
 			cg.OnHealthUpdate(healthcheck.StatusWarning)
 			So(cg.initialState, ShouldEqual, Stopped)
 		})
 
-		Convey("When a notification of an 'CRITICAL' health status is received, then the consumer-group is started", func() {
+		Convey("When a notification of an 'CRITICAL' health status is received, then the consumer-group is stopped", func() {
 			cg.OnHealthUpdate(healthcheck.StatusCritical)
 			So(cg.initialState, ShouldEqual, Stopped)
 		})

--- a/consumer_handler.go
+++ b/consumer_handler.go
@@ -30,6 +30,99 @@ func shallCommit(err error) bool {
 	return true
 }
 
+// handleMessage is an aux func to handle one message.
+// The batch will be committed unless a 'Commiter' error is returned and its Commit() func returns false
+func (cg *ConsumerGroup) handleMessage(ctx context.Context, workerID int, msg Message) {
+	msgCtx, cancel := context.WithCancel(ctx)
+	err := cg.handler(msgCtx, workerID, msg)
+	cancel() // TODO we might need to cancel the context also when Sarama session Cleanup is called
+	commit := shallCommit(err)
+	if err != nil {
+		logData := UnwrapLogData(err) // this will unwrap any logData present in the error
+		logData["commit_message"] = commit
+		log.Error(ctx, "failed to handle message", err, logData)
+	}
+	if commit {
+		msg.Commit()
+	}
+}
+
+// handleBatch is an aux func to handle one batch.
+// The batch will be committed unless a 'Commiter' error is returned and its Commit() func returns false
+func (cg *ConsumerGroup) handleBatch(ctx context.Context, batch *Batch) {
+	batchCtx, cancel := context.WithCancel(ctx)
+	err := cg.batchHandler(batchCtx, batch.messages)
+	cancel() // TODO we might need to cancel the context also when Sarama session Cleanup is called
+	commit := shallCommit(err)
+	if err != nil {
+		logData := UnwrapLogData(err) // this will unwrap any logData present in the error
+		logData["commit_batch"] = commit
+		log.Error(ctx, "failed to handle message batch", err, logData)
+	}
+	if commit {
+		batch.Commit() // mark all messages and commit session
+	}
+	batch.Clear() // always clear batch
+}
+
+// consumeMessage is a looping func that listens to the Upstream channel and handles each received message
+func (cg *ConsumerGroup) consumeMessage(ctx context.Context, workerID int) {
+	defer cg.wgClose.Done()
+	for {
+		select {
+		case msg, ok := <-cg.Channels().Upstream:
+			if !ok {
+				log.Info(ctx, "upstream channel closed - closing event handler loop", log.Data{"worker_id": workerID})
+				return
+			}
+
+			cg.handleMessage(ctx, workerID, msg)
+
+			msg.Release()
+		case <-cg.channels.Closer:
+			log.Info(ctx, "closer channel closed - closing event handler loop", log.Data{"worker_id": workerID})
+			return
+		}
+	}
+}
+
+// consumeBatch is a looping func that listens to the Upstream channel, accumulates messages and handles
+// batches once it is full or the waitTime has expired.
+func (cg *ConsumerGroup) consumeBatch(ctx context.Context) {
+	defer cg.wgClose.Done()
+	batch := NewBatch(cg.batchSize)
+
+	for {
+		select {
+		case msg, ok := <-cg.Channels().Upstream:
+			if !ok {
+				log.Info(ctx, "upstream channel closed - closing event batch handler loop")
+				return
+			}
+
+			batch.Add(ctx, msg)
+			if batch.IsFull() {
+				log.Info(ctx, "batch is full - processing batch", log.Data{"batchsize": batch.Size()})
+				cg.handleBatch(ctx, batch)
+			}
+
+			msg.Release() // always release the message
+
+		case <-time.After(cg.batchWaitTime):
+			if batch.IsEmpty() {
+				continue
+			}
+
+			log.Info(ctx, "batch wait time reached - processing batch", log.Data{"batchsize": batch.Size()})
+			cg.handleBatch(ctx, batch)
+
+		case <-cg.channels.Closer:
+			log.Info(ctx, "closer channel closed - closing event batch handler loop")
+			return
+		}
+	}
+}
+
 // listen creates one go-routine for each worker, which listens to the Upstream channel
 // when a new message arrives to the channel, the handler func is called.
 // when the closer channel is closed, all go-routines will exit (after finishing processing any in-flight message)
@@ -38,46 +131,10 @@ func (cg *ConsumerGroup) listen(ctx context.Context) {
 		return
 	}
 
-	// handleMessage is an aux func to handle one message.
-	// The batch will be committed unless a 'Commiter' error is returned and its Commit() func returns false
-	var handleMessage = func(workerID int, msg Message) {
-		err := cg.handler(context.Background(), workerID, msg)
-		commit := shallCommit(err)
-		if err != nil {
-			logData := UnwrapLogData(err) // this will unwrap any logData present in the error
-			logData["commit_message"] = commit
-			log.Error(ctx, "failed to handle message", err, logData)
-		}
-		if commit {
-			msg.Commit()
-		}
-	}
-
-	// consume is a looping func that listens to the Upstream channel and handles each received message
-	var consume = func(workerID int) {
-		defer cg.wgClose.Done()
-		for {
-			select {
-			case msg, ok := <-cg.Channels().Upstream:
-				if !ok {
-					log.Info(ctx, "upstream channel closed - closing event handler loop", log.Data{"worker_id": workerID})
-					return
-				}
-
-				handleMessage(workerID, msg)
-
-				msg.Release()
-			case <-cg.channels.Closer:
-				log.Info(ctx, "closer channel closed - closing event handler loop", log.Data{"worker_id": workerID})
-				return
-			}
-		}
-	}
-
 	// workers to consume messages in parallel
 	cg.wgClose.Add(cg.numWorkers)
 	for w := 1; w <= cg.numWorkers; w++ {
-		go consume(w)
+		go cg.consumeMessage(ctx, w)
 	}
 }
 
@@ -89,59 +146,7 @@ func (cg *ConsumerGroup) listenBatch(ctx context.Context) {
 		return
 	}
 
-	// handleBatch is an aux func to handle one batch.
-	// The batch will be committed unless a 'Commiter' error is returned and its Commit() func returns false
-	var handleBatch = func(batch *Batch) {
-		err := cg.batchHandler(ctx, batch.messages)
-		commit := shallCommit(err)
-		if err != nil {
-			logData := UnwrapLogData(err) // this will unwrap any logData present in the error
-			logData["commit_batch"] = commit
-			log.Error(ctx, "failed to handle message batch", err, logData)
-		}
-		if commit {
-			batch.Commit() // mark all messages and commit session
-		}
-		batch.Clear() // always clear batch
-	}
-
-	// consume is a looping func that listens to the Upstream channel, accumulates messages and handles
-	// batches once it is full or the waitTime has expired.
-	var consume = func() {
-		defer cg.wgClose.Done()
-		batch := NewBatch(cg.batchSize)
-
-		for {
-			select {
-			case msg, ok := <-cg.Channels().Upstream:
-				if !ok {
-					log.Info(ctx, "upstream channel closed - closing event batch handler loop")
-					return
-				}
-
-				batch.Add(ctx, msg)
-				if batch.IsFull() {
-					log.Info(ctx, "batch is full - processing batch", log.Data{"batchsize": batch.Size()})
-					handleBatch(batch)
-				}
-
-				msg.Release() // always release the message
-
-			case <-time.After(cg.batchWaitTime):
-				if batch.IsEmpty() {
-					continue
-				}
-
-				log.Info(ctx, "batch wait time reached - processing batch", log.Data{"batchsize": batch.Size()})
-				handleBatch(batch)
-
-			case <-cg.channels.Closer:
-				log.Info(ctx, "closer channel closed - closing event batch handler loop")
-				return
-			}
-		}
-	}
-
+	// only 1 worker is created for batch handling
 	cg.wgClose.Add(1)
-	go consume()
+	go cg.consumeBatch(ctx)
 }

--- a/consumer_sarama_handler_test.go
+++ b/consumer_sarama_handler_test.go
@@ -25,7 +25,8 @@ func TestSetup(t *testing.T) {
 	Convey("Given a saramaCgHandler with channels, and a sarama ConsumerGroupSession mock", t, func(c C) {
 		bufferSize := 1
 		channels := CreateConsumerGroupChannels(bufferSize)
-		cgState := NewConsumerStateMachine(Starting)
+		cgState := NewConsumerStateMachine()
+		cgState.Set(Starting)
 		cgHandler := newSaramaHandler(ctx, channels, cgState)
 		cgSession := &mock.SaramaConsumerGroupSessionMock{
 			ContextFunc:  func() context.Context { return ctx },
@@ -86,7 +87,8 @@ func TestControlRoutine(t *testing.T) {
 	Convey("Given a saramaCgHandler with channels, a sarama ConsumerGroupSession mock in Consuming state and a newly created sessionConsuming channel", t, func() {
 		bufferSize := 1
 		channels := CreateConsumerGroupChannels(bufferSize)
-		cgState := NewConsumerStateMachine(Consuming)
+		cgState := NewConsumerStateMachine()
+		cgState.Set(Consuming)
 		cgHandler := newSaramaHandler(ctx, channels, cgState)
 		close(channels.Initialised)
 		cgHandler.sessionConsuming = make(chan struct{})
@@ -155,7 +157,8 @@ func TestCleanup(t *testing.T) {
 
 		bufferSize := 1
 		channels := CreateConsumerGroupChannels(bufferSize)
-		cgState := NewConsumerStateMachine(Consuming)
+		cgState := NewConsumerStateMachine()
+		cgState.Set(Consuming)
 		cgHandler := newSaramaHandler(ctx, channels, cgState)
 		cgSession := &mock.SaramaConsumerGroupSessionMock{
 			ContextFunc:  func() context.Context { return ctx },
@@ -210,7 +213,8 @@ func TestConsume(t *testing.T) {
 
 		bufferSize := 1
 		channels := CreateConsumerGroupChannels(bufferSize)
-		cgState := NewConsumerStateMachine(Consuming)
+		cgState := NewConsumerStateMachine()
+		cgState.Set(Consuming)
 		cgHandler := newSaramaHandler(ctx, channels, cgState)
 		cgSession := &mock.SaramaConsumerGroupSessionMock{
 			ContextFunc:  func() context.Context { return ctx },

--- a/consumer_sarama_interface.go
+++ b/consumer_sarama_interface.go
@@ -18,6 +18,4 @@ type SaramaConsumerGroupClaim = sarama.ConsumerGroupClaim
 // Types for sarama initialisers
 type consumerGroupInitialiser = func(addrs []string, groupID string, config *sarama.Config) (sarama.ConsumerGroup, error)
 
-var saramaNewConsumerGroup = func(addrs []string, groupID string, config *sarama.Config) (sarama.ConsumerGroup, error) {
-	return sarama.NewConsumerGroup(addrs, groupID, config)
-}
+var saramaNewConsumerGroup = sarama.NewConsumerGroup

--- a/consumer_state.go
+++ b/consumer_state.go
@@ -101,16 +101,16 @@ func (sm *StateMachine) transitionTo(newState State) {
 
 	switch newState {
 	case Initialising:
-		close(sm.channels.Initialising)
+		SafeClose(sm.channels.Initialising)
 	case Stopped:
-		close(sm.channels.Stopped)
+		SafeClose(sm.channels.Stopped)
 	case Starting:
-		close(sm.channels.Starting)
+		SafeClose(sm.channels.Starting)
 	case Consuming:
-		close(sm.channels.Consuming)
+		SafeClose(sm.channels.Consuming)
 	case Stopping:
-		close(sm.channels.Stopping)
+		SafeClose(sm.channels.Stopping)
 	case Closing:
-		close(sm.channels.Closing)
+		SafeClose(sm.channels.Closing)
 	}
 }

--- a/consumer_state_test.go
+++ b/consumer_state_test.go
@@ -1,0 +1,71 @@
+package kafka
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSet(t *testing.T) {
+	Convey("Given a consumer-group state machine", t, func() {
+		sm := NewConsumerStateMachine()
+
+		validateTransition(sm, Stopped, sm.channels.Stopped, sm.channels.Initialising)
+		validateTransition(sm, Starting, sm.channels.Starting, sm.channels.Stopped)
+		validateTransition(sm, Consuming, sm.channels.Consuming, sm.channels.Starting)
+		validateTransition(sm, Stopping, sm.channels.Stopping, sm.channels.Consuming)
+		validateTransition(sm, Closing, sm.channels.Closing, sm.channels.Stopping)
+	})
+}
+
+func TestSetIf(t *testing.T) {
+	Convey("Given a consumer-group state machine in Stopped state, with the Stopped channel closed", t, func(c C) {
+		sm := NewConsumerStateMachine()
+		sm.Set(Stopped)
+		validateChanClosed(c, sm.channels.Stopped, true)
+
+		Convey("Then calling SetIf with an initial state condition that does not contain Stopped state results in the state not being changed and the channels remaining the same", func(c C) {
+			sm.SetIf([]State{Consuming}, Starting)
+			So(sm.state, ShouldEqual, Stopped)
+			validateChanClosed(c, sm.channels.Stopped, true)
+			validateChanClosed(c, sm.channels.Starting, false)
+		})
+
+		Convey("Then calling SetIf with an initial state condition that does contain Stopped state results in the state being changed and the channels being closed and created accordingly", func(c C) {
+			sm.SetIf([]State{Consuming, Stopped}, Starting)
+			So(sm.state, ShouldEqual, Starting)
+			validateChanClosed(c, sm.channels.Stopped, false)
+			validateChanClosed(c, sm.channels.Starting, true)
+		})
+	})
+}
+
+func validateTransition(sm *StateMachine, newState State, chNewState, chOldState chan struct{}) {
+	Convey(fmt.Sprintf("When the %s state is set", newState), func(c C) {
+		waiting := true
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-chNewState
+			waiting = false
+		}()
+
+		time.Sleep(5 * time.Millisecond)
+		So(waiting, ShouldBeTrue)
+		sm.Set(newState)
+
+		Convey(fmt.Sprintf("Then the %s channel is closed by the 'Set' call, and it remains closed", newState), func() {
+			wg.Wait()
+			So(waiting, ShouldBeFalse)
+			validateChanClosed(c, chNewState, true)
+		})
+
+		Convey("And the previous state channel is created again", func() {
+			validateChanClosed(c, chOldState, false)
+		})
+	})
+}

--- a/examples/consumer-batch/service/service.go
+++ b/examples/consumer-batch/service/service.go
@@ -71,7 +71,7 @@ func (svc *Service) Start(ctx context.Context) (err error) {
 
 func (svc *Service) Close(ctx context.Context) error {
 	log.Info(ctx, "[KAFKA-TEST] Commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": svc.cfg.GracefulShutdownTimeout})
-	ctx, cancel := context.WithTimeout(context.Background(), svc.cfg.GracefulShutdownTimeout)
+	ctx, cancel := context.WithTimeout(ctx, svc.cfg.GracefulShutdownTimeout)
 	var shutdownErr error
 
 	go func() {

--- a/examples/consumer/service/service.go
+++ b/examples/consumer/service/service.go
@@ -79,7 +79,7 @@ func (svc *Service) Start(ctx context.Context) (err error) {
 
 func (svc *Service) Close(ctx context.Context) error {
 	log.Info(ctx, "[KAFKA-TEST] Commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": svc.cfg.GracefulShutdownTimeout})
-	ctx, cancel := context.WithTimeout(context.Background(), svc.cfg.GracefulShutdownTimeout)
+	ctx, cancel := context.WithTimeout(ctx, svc.cfg.GracefulShutdownTimeout)
 	var shutdownErr error
 
 	go func() {

--- a/examples/producer/service/service.go
+++ b/examples/producer/service/service.go
@@ -111,7 +111,7 @@ func (svc *Service) Start(ctx context.Context, cancel context.CancelFunc) (err e
 
 func (svc *Service) Close(ctx context.Context) error {
 	log.Info(ctx, "[KAFKA-TEST] Commencing graceful shutdown", log.Data{"graceful_shutdown_timeout": svc.cfg.GracefulShutdownTimeout})
-	ctx, cancel := context.WithTimeout(context.Background(), svc.cfg.GracefulShutdownTimeout)
+	ctx, cancel := context.WithTimeout(ctx, svc.cfg.GracefulShutdownTimeout)
 	var shutdownErr error
 
 	go func() {

--- a/global.go
+++ b/global.go
@@ -44,7 +44,7 @@ func GetRetryTime(attempt int, retryTime, maxRetryTime time.Duration) time.Durat
 
 	// add or subtract a random factor of up to 25%
 	rnd := (rand.Int63n(50) - 25) * retryTime.Milliseconds() / 100
-	retryPause = retryPause + time.Duration(rnd)*time.Millisecond
+	retryPause += time.Duration(rnd) * time.Millisecond
 
 	// cap the value to MaxRetryInterval if it was exceeded
 	if retryPause > maxRetryTime {

--- a/global.go
+++ b/global.go
@@ -9,30 +9,10 @@ import (
 	"github.com/Shopify/sarama"
 )
 
-// Common constants
-const (
-	OffsetNewest = sarama.OffsetNewest
-	OffsetOldest = sarama.OffsetOldest
-)
-
-// InitRetryPeriod is the initial time period between initialisation retries (for producers and consumer gropus)
-var InitRetryPeriod = 250 * time.Millisecond
-
-// ConsumeErrRetryPeriod is the initial time period between consumer retries on error (for consumer groups)
-var ConsumeErrRetryPeriod = 250 * time.Millisecond
-
-// MaxRetryInterval is the maximum time between retries (plus or minus a random amount)
-var MaxRetryInterval = 31 * time.Second
-
 // SetMaxMessageSize sets the Sarama MaxRequestSize and MaxResponseSize values to the provided maxSize
 func SetMaxMessageSize(maxSize int32) {
 	sarama.MaxRequestSize = maxSize
 	sarama.MaxResponseSize = maxSize
-}
-
-// SetMaxRetryInterval sets MaxRetryInterval to its duration argument
-func SetMaxRetryInterval(maxPause time.Duration) {
-	MaxRetryInterval = maxPause
 }
 
 // maxAttempts calculates the maximum number of attempts

--- a/global.go
+++ b/global.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"math"
 	"math/rand"
 	"sync"
@@ -54,16 +53,17 @@ func GetRetryTime(attempt int, retryTime time.Duration) time.Duration {
 // WaitWithTimeout blocks until all go-routines tracked by a WaitGroup are done,
 // or until the timeout defined in a context expires.
 // It returns true only if the context timeout expired
-func WaitWithTimeout(ctx context.Context, wg *sync.WaitGroup) bool {
+func WaitWithTimeout(wg *sync.WaitGroup) bool {
 	chWaiting := make(chan struct{})
 	go func() {
 		defer close(chWaiting)
 		wg.Wait()
 	}()
+
 	select {
 	case <-chWaiting:
 		return false
-	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
 		return true
 	}
 }

--- a/global_test.go
+++ b/global_test.go
@@ -7,47 +7,48 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func TestMaxAttempts(t *testing.T) {
+	Convey("Given a valid retry interval and power of 2 MaxRetryInterval then 'maxAttempts' returns the expected value for number of attempts", t, func() {
+		maxRetryTime := 32 * time.Second
+		retryTime := 1 * time.Second
+		m := maxAttempts(retryTime, maxRetryTime)
+		So(m, ShouldEqual, 5)
+	})
+
+	Convey("Given a valid retry interval and MaxRetryInterval then 'maxAttempts' returns the expected value for number of attempts", t, func() {
+		maxRetryTime := 31 * time.Second
+		retryTime := 1 * time.Second
+		m := maxAttempts(retryTime, maxRetryTime)
+		So(m, ShouldEqual, 4)
+	})
+}
+
 func TestGetRetryTime(t *testing.T) {
+	Convey("given valid max retry and initial retry intervals", t, func() {
+		maxRetryTime := 25601 * time.Millisecond // near 25.6 sec, so that MaxRetryInterval check is likely triggered
+		initialInterval := 200 * time.Millisecond
 
-	Convey("Given a valid retry interval", t, func() {
+		Convey("Then providing a value lower than 1 to GetRetryTime results in a value within 25 percent of initialInterval being returned", func() {
+			interval := GetRetryTime(-1, initialInterval, maxRetryTime)
+			So(interval, ShouldBeBetweenOrEqual, initialInterval*75/100, initialInterval*125/100)
+			interval = GetRetryTime(0, initialInterval, maxRetryTime)
+			So(interval, ShouldBeBetweenOrEqual, initialInterval*75/100, initialInterval*125/100)
+			interval = GetRetryTime(1, initialInterval, maxRetryTime)
+			So(interval, ShouldBeBetweenOrEqual, initialInterval*75/100, initialInterval*125/100)
+		})
 
-		var initialInterval_ms int64 = 200
-		initialInterval := time.Duration(initialInterval_ms) * time.Millisecond
-
-		Convey("getRetryTime returns sane progression over many attempts", func() {
-			maxInterval_ms := MaxRetryInterval.Milliseconds()
+		Convey("Then the interval for each iteration has a value that falls within 25 percent of 2^n, resetting n every time that MaxRetryInterval is reached", func() {
 			expectedInterval := initialInterval
-			powerHasWrapped := false
-
 			for attempt := 1; attempt < 100; attempt++ {
-				// get computed interval
-				interval := GetRetryTime(attempt, initialInterval)
-				interval_ms := interval.Milliseconds()
-
-				expectedInterval_ms := expectedInterval.Milliseconds()
-
-				So(interval_ms, ShouldBeGreaterThanOrEqualTo, initialInterval_ms/100*75)
-				if powerHasWrapped {
-					So(interval_ms, ShouldBeGreaterThan, maxInterval_ms-initialInterval_ms)
-				} else {
-					// when values have not wrapped/overflowed
-					possiblyOverInterval := expectedInterval_ms + initialInterval_ms
-					if possiblyOverInterval < MaxRetryInterval.Milliseconds() {
-						// and not over MaxRetryInterval yet
-						So(interval_ms, ShouldBeBetween,
-							expectedInterval_ms-initialInterval_ms,
-							expectedInterval_ms+initialInterval_ms)
-					}
-
-				}
-				So(interval_ms, ShouldBeLessThan, maxInterval_ms+initialInterval_ms)
+				interval := GetRetryTime(attempt, initialInterval, maxRetryTime)
+				So(interval, ShouldBeBetweenOrEqual, expectedInterval*75/100, expectedInterval*125/100)
+				So(interval, ShouldBeLessThanOrEqualTo, MaxRetryInterval)
 
 				expectedInterval *= 2
-				if expectedInterval <= 0 {
-					powerHasWrapped = true
+				if expectedInterval >= maxRetryTime {
+					expectedInterval = initialInterval
 				}
 			}
 		})
 	})
-
 }

--- a/global_test.go
+++ b/global_test.go
@@ -42,7 +42,7 @@ func TestGetRetryTime(t *testing.T) {
 			for attempt := 1; attempt < 100; attempt++ {
 				interval := GetRetryTime(attempt, initialInterval, maxRetryTime)
 				So(interval, ShouldBeBetweenOrEqual, expectedInterval*75/100, expectedInterval*125/100)
-				So(interval, ShouldBeLessThanOrEqualTo, MaxRetryInterval)
+				So(interval, ShouldBeLessThanOrEqualTo, maxRetryTime)
 
 				expectedInterval *= 2
 				if expectedInterval >= maxRetryTime {

--- a/global_test.go
+++ b/global_test.go
@@ -8,24 +8,24 @@ import (
 )
 
 func TestMaxAttempts(t *testing.T) {
-	Convey("Given a valid retry interval and power of 2 MaxRetryInterval then 'maxAttempts' returns the expected value for number of attempts", t, func() {
-		maxRetryTime := 32 * time.Second
+	Convey("Given a valid retry interval and power of 2 'maxRetryPeriod' then 'maxAttempts' returns the expected value for number of attempts", t, func() {
+		maxRetryPeriod := 32 * time.Second
 		retryTime := 1 * time.Second
-		m := maxAttempts(retryTime, maxRetryTime)
+		m := maxAttempts(retryTime, maxRetryPeriod)
 		So(m, ShouldEqual, 5)
 	})
 
-	Convey("Given a valid retry interval and MaxRetryInterval then 'maxAttempts' returns the expected value for number of attempts", t, func() {
-		maxRetryTime := 31 * time.Second
+	Convey("Given a valid retry interval and 'maxRetryPeriod' then 'maxAttempts' returns the expected value for number of attempts", t, func() {
+		maxRetryPeriod := 31 * time.Second
 		retryTime := 1 * time.Second
-		m := maxAttempts(retryTime, maxRetryTime)
+		m := maxAttempts(retryTime, maxRetryPeriod)
 		So(m, ShouldEqual, 4)
 	})
 }
 
 func TestGetRetryTime(t *testing.T) {
 	Convey("given valid max retry and initial retry intervals", t, func() {
-		maxRetryTime := 25601 * time.Millisecond // near 25.6 sec, so that MaxRetryInterval check is likely triggered
+		maxRetryTime := 25601 * time.Millisecond // near 25.6 sec, so that maxRetryPeriod check is likely to be triggered
 		initialInterval := 200 * time.Millisecond
 
 		Convey("Then providing a value lower than 1 to GetRetryTime results in a value within 25 percent of initialInterval being returned", func() {
@@ -37,7 +37,7 @@ func TestGetRetryTime(t *testing.T) {
 			So(interval, ShouldBeBetweenOrEqual, initialInterval*75/100, initialInterval*125/100)
 		})
 
-		Convey("Then the interval for each iteration has a value that falls within 25 percent of 2^n, resetting n every time that MaxRetryInterval is reached", func() {
+		Convey("Then the interval for each iteration has a value that falls within 25 percent of 2^n, resetting n every time that maxRetryTime is reached", func() {
 			expectedInterval := initialInterval
 			for attempt := 1; attempt < 100; attempt++ {
 				interval := GetRetryTime(attempt, initialInterval, maxRetryTime)

--- a/kafkatest/mocks_test.go
+++ b/kafkatest/mocks_test.go
@@ -8,8 +8,9 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestProducerMock(t *testing.T) {
+var ctx = context.Background()
 
+func TestProducerMock(t *testing.T) {
 	Convey("Given an uninitialised producer mock", t, func() {
 
 		producerMock := NewMessageProducer(false)
@@ -24,7 +25,7 @@ func TestProducerMock(t *testing.T) {
 				<-producerMock.Channels().Initialised
 				initClosed = true
 			}()
-			producerMock.Initialise(context.Background())
+			producerMock.Initialise(ctx)
 			So(producerMock.IsInitialised(), ShouldBeTrue)
 			wg.Wait()
 			So(initClosed, ShouldBeTrue)
@@ -40,7 +41,7 @@ func TestProducerMock(t *testing.T) {
 		So(producerMock.IsInitialised(), ShouldBeTrue)
 
 		Convey("Calling initialise again has no effect", func() {
-			producerMock.Initialise(context.Background())
+			producerMock.Initialise(ctx)
 			So(producerMock.IsInitialised(), ShouldBeTrue)
 		})
 
@@ -71,7 +72,7 @@ func validateCloseProducer(producerMock *MessageProducer) {
 		<-producerMock.Channels().Closed
 		closedClosed = true
 	}()
-	producerMock.Close(context.Background())
+	producerMock.Close(ctx)
 	wg.Wait()
 
 	So(closedOutput, ShouldBeTrue)
@@ -81,7 +82,6 @@ func validateCloseProducer(producerMock *MessageProducer) {
 }
 
 func TestConsumerMock(t *testing.T) {
-
 	Convey("Given an uninitialised consumer mock", t, func() {
 		consumerMock := NewMessageConsumer(false)
 		So(consumerMock.IsInitialised(), ShouldBeFalse)
@@ -95,7 +95,7 @@ func TestConsumerMock(t *testing.T) {
 				<-consumerMock.Channels().Initialised
 				initClosed = true
 			}()
-			consumerMock.Initialise(context.Background())
+			consumerMock.Initialise(ctx)
 			So(consumerMock.IsInitialised(), ShouldBeTrue)
 			wg.Wait()
 			So(initClosed, ShouldBeTrue)
@@ -111,7 +111,7 @@ func TestConsumerMock(t *testing.T) {
 		So(consumerMock.IsInitialised(), ShouldBeTrue)
 
 		Convey("Calling initialise again has no effect", func() {
-			consumerMock.Initialise(context.Background())
+			consumerMock.Initialise(ctx)
 			So(consumerMock.IsInitialised(), ShouldBeTrue)
 		})
 
@@ -266,7 +266,7 @@ func validateCloseConsumer(consumerMock *MessageConsumer) {
 		<-consumerMock.Channels().Closed
 		closedClosed = true
 	}()
-	consumerMock.Close(context.Background())
+	consumerMock.Close(ctx)
 	wg.Wait()
 
 	So(closedUpstream, ShouldBeTrue)

--- a/message.go
+++ b/message.go
@@ -47,39 +47,39 @@ func NewSaramaMessage(m *sarama.ConsumerMessage, s sarama.ConsumerGroupSession, 
 }
 
 // GetData returns the message contents.
-func (M SaramaMessage) GetData() []byte {
-	return M.message.Value
+func (m SaramaMessage) GetData() []byte {
+	return m.message.Value
 }
 
 // Offset returns the message offset
-func (M SaramaMessage) Offset() int64 {
-	return M.message.Offset
+func (m SaramaMessage) Offset() int64 {
+	return m.message.Offset
 }
 
 // Mark marks the message as consumed, but doesn't commit the offset to the backend
-func (M SaramaMessage) Mark() {
-	M.session.MarkMessage(M.message, "metadata")
+func (m SaramaMessage) Mark() {
+	m.session.MarkMessage(m.message, "metadata")
 }
 
 // Commit marks the message as consumed, and then commits the offset to the backend
-func (M SaramaMessage) Commit() {
-	M.session.MarkMessage(M.message, "metadata")
-	M.session.Commit()
+func (m SaramaMessage) Commit() {
+	m.session.MarkMessage(m.message, "metadata")
+	m.session.Commit()
 }
 
 // Release closes the UpstreamDone channel, but doesn't mark the message or commit the offset
-func (M SaramaMessage) Release() {
-	SafeClose(M.upstreamDone)
+func (m SaramaMessage) Release() {
+	SafeClose(m.upstreamDone)
 }
 
 // CommitAndRelease marks the message as consumed, commits the offset to the backend and releases the UpstreamDone channel
-func (M SaramaMessage) CommitAndRelease() {
-	M.session.MarkMessage(M.message, "metadata")
-	M.session.Commit()
-	SafeClose(M.upstreamDone)
+func (m SaramaMessage) CommitAndRelease() {
+	m.session.MarkMessage(m.message, "metadata")
+	m.session.Commit()
+	SafeClose(m.upstreamDone)
 }
 
 // UpstreamDone returns the upstreamDone channel. Closing this channel notifies that the message has been consumed (same effect as calling Release)
-func (M SaramaMessage) UpstreamDone() chan struct{} {
-	return M.upstreamDone
+func (m SaramaMessage) UpstreamDone() chan struct{} {
+	return m.upstreamDone
 }

--- a/message.go
+++ b/message.go
@@ -69,14 +69,14 @@ func (M SaramaMessage) Commit() {
 
 // Release closes the UpstreamDone channel, but doesn't mark the message or commit the offset
 func (M SaramaMessage) Release() {
-	close(M.upstreamDone)
+	SafeClose(M.upstreamDone)
 }
 
 // CommitAndRelease marks the message as consumed, commits the offset to the backend and releases the UpstreamDone channel
 func (M SaramaMessage) CommitAndRelease() {
 	M.session.MarkMessage(M.message, "metadata")
 	M.session.Commit()
-	close(M.upstreamDone)
+	SafeClose(M.upstreamDone)
 }
 
 // UpstreamDone returns the upstreamDone channel. Closing this channel notifies that the message has been consumed (same effect as calling Release)

--- a/producer_interface.go
+++ b/producer_interface.go
@@ -10,6 +10,4 @@ type SaramaAsyncProducer = sarama.AsyncProducer
 // Types for sarama initialisers
 type producerInitialiser = func(addrs []string, config *sarama.Config) (sarama.AsyncProducer, error)
 
-var saramaNewAsyncProducer = func(addrs []string, config *sarama.Config) (sarama.AsyncProducer, error) {
-	return sarama.NewAsyncProducer(addrs, config)
-}
+var saramaNewAsyncProducer = sarama.NewAsyncProducer

--- a/producer_test.go
+++ b/producer_test.go
@@ -221,24 +221,6 @@ func validateChannelReceivesError(ch chan error, expectedErr error) {
 	So(rxErr, ShouldResemble, expectedErr)
 }
 
-// validateChanClosed validates that a channel is closed before a timeout expires
-func validateChanClosed(c C, ch chan struct{}, expectedClosed bool) {
-	var (
-		closed  bool
-		timeout bool
-	)
-	select {
-	case _, ok := <-ch:
-		if !ok {
-			closed = true
-		}
-	case <-time.After(TIMEOUT):
-		timeout = true
-	}
-	c.So(timeout, ShouldNotEqual, expectedClosed)
-	c.So(closed, ShouldEqual, expectedClosed)
-}
-
 func TestProducerNotInitialised(t *testing.T) {
 	Convey("Given that Sarama fails to create a new AsyncProducer while we initialise our Producer", t, func() {
 		pInitCalls := 0


### PR DESCRIPTION
### What

This PR corresponds to a conversation with @redhug1 (context) and also the experience of using `dp-kafka` in component tests (need to wait until consumer is in `Consuming` state)

Fix usage of context:
- Create a new child context on message/batch handlers, which is cancelled as soon as the caller returns
- Close consumer/producer when a context.Done() is received
- Fixed bug with `waitWithTimeout` for expired contexts
- Added unit tests

Created channels for State transitions
- For each state transition, the consumer-group state machine closes the new state channel and opens a new channel for the old state.
- This means that a caller can block execution until a particular state is reached, like so (e.g. `Consuming` state):
```
<-consumer.Channels().State.Consuming
```

Update:
Extended PR to cover:
- Safe channel close/send and check ok on recieved values
- GetRetryPeriod now restarts the backoff algorithm after reaching the max period, and the values are configurable.

### How to review

- Make sure code changes make sense
- Make sure new unit tests make sense and cover new functionality
- Make sure unit tests pass
(info only): usage example: https://github.com/ONSdigital/dp-cantabular-csv-exporter/pull/36

### Who can review

anyone