### PR TITLE
change example ports to 39092, to match dp-compose values

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ the app itself needs to be updated to use TLS. To achieve this, please do the fo
    ```markdown
    | Environment variable         | Default                                   | Description
    | ---------------------------- | ----------------------------------------- | -----------
-   | KAFKA_ADDR                   | localhost:9092                            | The kafka broker addresses (can be comma separated)
+   | KAFKA_ADDR                   | localhost:39092                           | The kafka broker addresses (can be comma separated)
    | KAFKA_VERSION                | "1.0.2"                                   | The kafka version that this service expects to connect to
    | KAFKA_SEC_PROTO              | _unset_                                   | if set to `TLS`, kafka connections will use TLS [[1]](#notes_1)
    | KAFKA_SEC_CA_CERTS           | _unset_                                   | CA cert chain for the server cert [[1]](#notes_1)

--- a/examples/consumer-batch/config/config.go
+++ b/examples/consumer-batch/config/config.go
@@ -35,7 +35,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg := &Config{
-		Brokers:                 []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		Brokers:                 []string{"localhost:39092"},
 		KafkaMaxBytes:           50 * 1024 * 1024,
 		KafkaVersion:            "1.0.2",
 		ConsumedTopic:           "myTopic",

--- a/examples/consumer/config/config.go
+++ b/examples/consumer/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg := &Config{
-		Brokers:                 []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		Brokers:                 []string{"localhost:39092"},
 		KafkaMaxBytes:           50 * 1024 * 1024,
 		KafkaVersion:            "1.0.2",
 		ConsumedTopic:           "myTopic",

--- a/examples/producer/config/config.go
+++ b/examples/producer/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg := &Config{
-		Brokers:                 []string{"localhost:9092", "localhost:9093", "localhost:9094"},
+		Brokers:                 []string{"localhost:39092"},
 		KafkaMaxBytes:           50 * 1024 * 1024,
 		KafkaVersion:            "1.0.2",
 		ProducedTopic:           "myTopic",


### PR DESCRIPTION
### What

- Changed default ports to 39092 in examples to match new `dp-compose` port values

### How to review

- Make sure the 3 examples are changed
- (optional - I tested this myself)You may run the examples along with the latest `dp-compose`, and see that messages are produced and consumed as expected.

### Who can review

anyone