### PR TITLE
set global values in init() to prevent data races during runtime

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
-	"github.com/rcrowley/go-metrics"
 )
 
 //go:generate moq -out ./kafkatest/mock_consumer_group.go -pkg kafkatest . IConsumerGroup
@@ -114,9 +113,6 @@ func newConsumerGroup(ctx context.Context, cgConfig *ConsumerGroupConfig, cgInit
 			return
 		}
 	}()
-
-	// disable metrics to prevent memory leak on broker.Open()
-	metrics.UseNilMetrics = true
 
 	// create broker objects
 	for _, addr := range cg.brokerAddrs {

--- a/global.go
+++ b/global.go
@@ -7,7 +7,15 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/rcrowley/go-metrics"
 )
+
+// init is executed only once, when the package is imported.
+// Global variables are set here, to prevent any data race during runtime.
+func init() {
+	// disable metrics to prevent memory leak on broker.Open()
+	metrics.UseNilMetrics = true
+}
 
 // SetMaxMessageSize sets the Sarama MaxRequestSize and MaxResponseSize values to the provided maxSize
 func SetMaxMessageSize(maxSize int32) {

--- a/producer.go
+++ b/producer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ONSdigital/dp-kafka/v3/avro"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/Shopify/sarama"
-	"github.com/rcrowley/go-metrics"
 )
 
 //go:generate moq -out ./kafkatest/mock_producer.go -pkg kafkatest . IProducer
@@ -85,9 +84,6 @@ func newProducer(ctx context.Context, pConfig *ProducerConfig, pInit producerIni
 			return
 		}
 	}()
-
-	// disable metrics to prevent memory leak on broker.Open()
-	metrics.UseNilMetrics = true
 
 	// Create broker objects
 	for _, addr := range pConfig.BrokerAddrs {


### PR DESCRIPTION
### What

Bugfix: @redhug1  identified a data race in component tests caused by a global value being written by kafka constructors and read by sarama `Consume` func concurrently.

This PR fixes this data race by writing the value only once when the package is loaded, using an `init()` func
[more info on init() func here](https://stackoverflow.com/questions/24790175/when-is-the-init-function-run)

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info) tested with cantabular-csv-exporter, after setting the `-race` flag for component tests, and didn't see the data race again.
 
### Who can review

anyone