### PR TITLE
handle session channel concurrency properly

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -70,7 +70,8 @@ func (sc *StateChan) leave() {
 	sc.channel = make(chan struct{})
 }
 
-// Get returns the channel wrapped by this StateChan struct in a concurrency-safe manner
+// Get returns the channel wrapped by this StateChan struct in a concurrency-safe manner.
+// Note: if you intend to wait on this channel, please acquire a read lock on RWMutex()
 func (sc *StateChan) Channel() chan struct{} {
 	sc.mutex.RLock()
 	defer sc.mutex.RUnlock()

--- a/channels.go
+++ b/channels.go
@@ -71,7 +71,8 @@ func (sc *StateChan) leave() {
 }
 
 // Get returns the channel wrapped by this StateChan struct in a concurrency-safe manner.
-// Note: if you intend to wait on this channel, please acquire a read lock on RWMutex()
+// Note: if you intend to wait on this channel, you will need to acquire a read lock on RWMutex()
+// if you want to wait on the channel while a concurrent sc.leave() call may happen.
 func (sc *StateChan) Channel() chan struct{} {
 	sc.mutex.RLock()
 	defer sc.mutex.RUnlock()

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -125,7 +125,7 @@ func TestConsumerInitialised(t *testing.T) {
 				return nil
 			}
 			err := consumer.Close(ctx)
-			So(err, ShouldResemble, errors.New("error(s) closing broker connections: [kafka: broker not connected kafka: broker not connected kafka: broker not connected]"))
+			So(err, ShouldBeNil)
 			validateChanClosed(c, consumer.Channels().Closer, true)
 			validateChanClosed(c, consumer.Channels().Closed, true)
 			So(len(saramaConsumerGroupMock.CloseCalls()), ShouldEqual, 1)
@@ -166,7 +166,7 @@ func TestConsumerNotInitialised(t *testing.T) {
 
 		Convey("Closing the consumer closes the caller channels", func(c C) {
 			err := consumer.Close(ctx)
-			So(err, ShouldResemble, errors.New("error(s) closing broker connections: [kafka: broker not connected kafka: broker not connected kafka: broker not connected]"))
+			So(err, ShouldBeNil)
 			validateChanClosed(c, consumer.Channels().Closer, true)
 			validateChanClosed(c, consumer.Channels().Closed, true)
 		})

--- a/global.go
+++ b/global.go
@@ -64,7 +64,7 @@ func GetRetryTime(attempt int, retryTime, maxRetryTime time.Duration) time.Durat
 
 // WaitWithTimeout blocks until all go-routines tracked by a WaitGroup are done or a timeout expires.
 // It returns true if the timeout expired, or false if the waitgroup finished before the timeout.
-func WaitWithTimeout(wg *sync.WaitGroup) bool {
+func WaitWithTimeout(wg *sync.WaitGroup, tout time.Duration) bool {
 	chWaiting := make(chan struct{})
 	go func() {
 		defer SafeClose(chWaiting)
@@ -74,7 +74,7 @@ func WaitWithTimeout(wg *sync.WaitGroup) bool {
 	select {
 	case <-chWaiting:
 		return false
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(tout):
 		return true
 	}
 }

--- a/producer_test.go
+++ b/producer_test.go
@@ -190,7 +190,7 @@ func TestProducer(t *testing.T) {
 
 		Convey("Closing the producer closes Sarama producer and channels", func(c C) {
 			err := producer.Close(ctx)
-			So(err, ShouldResemble, errors.New("error(s) closing broker connections: [kafka: broker not connected kafka: broker not connected kafka: broker not connected]"))
+			So(err, ShouldBeNil)
 			validateChanClosed(c, producer.Channels().Closer, true)
 			validateChanClosed(c, producer.Channels().Closed, true)
 			So(len(asyncProducerMock.CloseCalls()), ShouldEqual, 1)
@@ -248,7 +248,7 @@ func TestProducerNotInitialised(t *testing.T) {
 
 		Convey("Closing the producer closes the caller channels", func(c C) {
 			err := producer.Close(ctx)
-			So(err, ShouldResemble, errors.New("error(s) closing broker connections: [kafka: broker not connected kafka: broker not connected kafka: broker not connected]"))
+			So(err, ShouldBeNil)
 			validateChanClosed(c, producer.Channels().Closer, true)
 			validateChanClosed(c, producer.Channels().Closed, true)
 		})


### PR DESCRIPTION
### What

- Fixed concurrency for Sarama Session channel 
- Changed some logs to display
- Increase Close timeout to 2 seconds (instead of 0.5), when it wait for all go-routines to finish.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info) tested with the examples (consumer and producer)

### Who can review

anyone