### PR TITLE
Feature/fix time after useage

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,12 +430,14 @@ For example:
     m := consumer.Channels().State.Consuming.RWMutex()
     m.RLock()
 
+    delay := time.NewTimer(someTime)
     select {
-    case <-time.After(someTime):
+    case <-delay.C:
         m.RUnlock()
         ...
     case <-consumer.Channels().State.Consuming.Channel()
         m.RUnlock()
+        // release the 'delay' timer as what is done in the code base
         ...
     }
     ...

--- a/channels_test.go
+++ b/channels_test.go
@@ -354,12 +354,18 @@ func validateChanClosed(c C, ch chan struct{}, expectedClosed bool) {
 		closed  bool
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case _, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			closed = true
 		}
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	c.So(timeout, ShouldNotEqual, expectedClosed)
@@ -372,12 +378,18 @@ func validateChanBoolClosed(c C, ch chan bool, expectedClosed bool) {
 		closed  bool
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case _, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			closed = true
 		}
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	c.So(timeout, ShouldNotEqual, expectedClosed)
@@ -390,12 +402,18 @@ func validateChanMessageClosed(c C, ch chan Message, expectedClosed bool) {
 		closed  bool
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case _, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			closed = true
 		}
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	c.So(timeout, ShouldNotEqual, expectedClosed)
@@ -408,12 +426,18 @@ func validateChanBytesClosed(c C, ch chan []byte, expectedClosed bool) {
 		closed  bool
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case _, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			closed = true
 		}
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	c.So(timeout, ShouldNotEqual, expectedClosed)
@@ -426,12 +450,18 @@ func validateChanErrClosed(c C, ch chan error, expectedClosed bool) {
 		closed  bool
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case _, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			closed = true
 		}
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	c.So(timeout, ShouldNotEqual, expectedClosed)
@@ -444,13 +474,19 @@ func validateChanReceivesBool(ch chan bool, expectedVal bool) {
 		rxVal   bool
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case val, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			break
 		}
 		rxVal = val
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	So(timeout, ShouldBeFalse)
@@ -463,13 +499,19 @@ func validateChanReceivesBytes(ch chan []byte, expectedVal []byte) {
 		rxVal   []byte
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case val, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			break
 		}
 		rxVal = val
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	So(timeout, ShouldBeFalse)
@@ -482,13 +524,19 @@ func validateChanReceivesProducerMessage(ch chan *sarama.ProducerMessage, expect
 		rxVal   *sarama.ProducerMessage
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case e, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			break
 		}
 		rxVal = e
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	So(timeout, ShouldBeFalse)
@@ -501,13 +549,19 @@ func validateChanReceivesErr(ch chan error, expectedErr error) {
 		rxVal   error
 		timeout bool
 	)
+	delay := time.NewTimer(TIMEOUT)
 	select {
 	case e, ok := <-ch:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		if !ok {
 			break
 		}
 		rxVal = e
-	case <-time.After(TIMEOUT):
+	case <-delay.C:
 		timeout = true
 	}
 	So(timeout, ShouldBeFalse)

--- a/examples/consumer/service/service.go
+++ b/examples/consumer/service/service.go
@@ -125,12 +125,18 @@ func (svc *Service) Close(ctx context.Context) error {
 func createTickerLoop(ctx context.Context, cg *kafka.ConsumerGroup) {
 	go func() {
 		for {
+			delay := time.NewTimer(ticker)
 			select {
-			case <-time.After(ticker):
+			case <-delay.C:
 				log.Info(ctx, "[KAFKA-TEST] tick ", log.Data{
 					"state": cg.State().String(),
 				})
 			case <-cg.Channels().Closed:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				log.Info(ctx, "[KAFKA-TEST] tick - CLOSED - ", log.Data{
 					"state": cg.State().String(),
 				})
@@ -147,8 +153,9 @@ func createStartStopLoop(ctx context.Context, cg *kafka.ConsumerGroup) {
 	// consume start-stop loop
 	go func() {
 		for {
+			delay := time.NewTimer(startStop)
 			select {
-			case <-time.After(startStop):
+			case <-delay.C:
 				logData := log.Data{
 					"state": cg.State().String(),
 				}
@@ -183,6 +190,11 @@ func createStartStopLoop(ctx context.Context, cg *kafka.ConsumerGroup) {
 				default:
 				}
 			case <-cg.Channels().Closed:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				log.Info(ctx, "[KAFKA-TEST] consume loop - CLOSED - ", log.Data{
 					"state": cg.State().String(),
 				})

--- a/examples/producer/service/service.go
+++ b/examples/producer/service/service.go
@@ -89,16 +89,27 @@ func (svc *Service) Start(ctx context.Context, cancel context.CancelFunc) (err e
 		defer cancel()
 		defer close(eventLoopDone)
 		for {
+			delay := time.NewTimer(ticker)
 			select {
 
-			case <-time.After(ticker):
+			case <-delay.C:
 				log.Info(ctx, "[KAFKA-TEST] tick")
 
 			case <-eventLoopContext.Done():
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				log.Info(ctx, "[KAFKA-TEST] Event loop context done", log.Data{"eventLoopContextErr": eventLoopContext.Err()})
 				return
 
 			case stdinLine := <-stdinChannel:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				// Used for this example to write messages to kafka consumer topic (should not be needed in applications)
 				svc.producer.Channels().Output <- []byte(stdinLine)
 				log.Info(ctx, "[KAFKA-TEST] Message output", log.Data{"messageSent": stdinLine, "messageChars": []byte(stdinLine)})

--- a/global.go
+++ b/global.go
@@ -71,10 +71,16 @@ func WaitWithTimeout(wg *sync.WaitGroup, tout time.Duration) bool {
 		wg.Wait()
 	}()
 
+	delay := time.NewTimer(tout)
 	select {
 	case <-chWaiting:
+		// Ensure timer is stopped and its resources are freed
+		if !delay.Stop() {
+			// if the timer has been stopped then read from the channel
+			<-delay.C
+		}
 		return false
-	case <-time.After(tout):
+	case <-delay.C:
 		return true
 	}
 }


### PR DESCRIPTION
### What

time.After() usage was leaking resources according to this article:
https://www.arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/

These changes are to fix all possible instances of that issue.

### How to review

Visually check changes.
do 'make test'

### Who can review

Anyone, possibly Gedge, Joshua, Nathan
