### PR TITLE
Feature/fix time after

### DIFF
--- a/health_info.go
+++ b/health_info.go
@@ -49,7 +49,7 @@ func (h *HealthInfoMap) UpdateStatus(state *health.CheckState, minHealthyThresho
 
 // ErrorMsg returns an tailored message according to the information kept in HealthInfoMap
 func (h *HealthInfoMap) ErrorMsg() string {
-	errorMsg := ""
+	var errorMsg string
 
 	unreachableAddrs := []string{}
 	for broker, healthInfo := range *h {

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -9,20 +9,22 @@ import (
 	"github.com/Shopify/sarama"
 )
 
-// ServiceName is the name of this service: Kafka.
-const ServiceName = "Kafka"
+const (
+	// ServiceName is the name of this service: Kafka.
+	ServiceName = "Kafka"
 
-// MsgHealthyProducer Check message returned when Kafka producer is healthy.
-const MsgHealthyProducer = "kafka producer is healthy"
+	// MsgHealthyProducer Check message returned when Kafka producer is healthy.
+	MsgHealthyProducer = "kafka producer is healthy"
 
-// MsgHealthyConsumerGroup Check message returned when Kafka consumer group is healthy.
-const MsgHealthyConsumerGroup = "kafka consumer group is healthy"
+	// MsgHealthyConsumerGroup Check message returned when Kafka consumer group is healthy.
+	MsgHealthyConsumerGroup = "kafka consumer group is healthy"
 
-// ProducerMinBrokersHealthy is the minimum number of healthy brokers required for a healthcheck to not be considered critical for a producer
-const ProducerMinBrokersHealthy = 2
+	// ProducerMinBrokersHealthy is the minimum number of healthy brokers required for a healthcheck to not be considered critical for a producer
+	ProducerMinBrokersHealthy = 2
 
-// ProducerMinBrokersHealthy is the minimum number of healthy brokers required for a healthcheck to not be considered critical for a consumer
-const ConsumerMinBrokersHealthy = 1
+	// ProducerMinBrokersHealthy is the minimum number of healthy brokers required for a healthcheck to not be considered critical for a consumer
+	ConsumerMinBrokersHealthy = 1
+)
 
 // Checker checks health of Kafka producer and updates the provided CheckState accordingly
 func (p *Producer) Checker(ctx context.Context, state *health.CheckState) error {


### PR DESCRIPTION
### What

NOTE: This is on the V2 'branch'

time.After() usage was leaking resources according to this article:
https://www.arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/

These changes are to fix all possible instances of that issue.

### How to review

Visually check changes.
do 'make test'

### Who can review

Anyone, possibly Nathan