### PR TITLE
Add missing mock methods for sarama consumer group

### DIFF
--- a/mock/sarama_cg.go
+++ b/mock/sarama_cg.go
@@ -45,6 +45,18 @@ type SaramaConsumerGroupMock struct {
 	// ErrorsFunc mocks the Errors method.
 	ErrorsFunc func() <-chan error
 
+	// PauseFunc mocks the Pause method.
+	PauseFunc func(topicPartitions map[string][]int32)
+
+	// PauseAllFunc mocks the PauseAll method.
+	PauseAllFunc func()
+
+	// ResumeFunc mocks the Resume method.
+	ResumeFunc func(topicPartitions map[string][]int32)
+
+	// ResumeAllFunc mocks the ResumeAll method.
+	ResumeAllFunc func()
+
 	// calls tracks calls to the methods.
 	calls struct {
 		// Close holds details about calls to the Close method.
@@ -66,6 +78,18 @@ type SaramaConsumerGroupMock struct {
 	lockClose   sync.RWMutex
 	lockConsume sync.RWMutex
 	lockErrors  sync.RWMutex
+}
+
+func (mock *SaramaConsumerGroupMock) Pause(topicPartitions map[string][]int32) {
+}
+
+func (mock *SaramaConsumerGroupMock) PauseAll() {
+}
+
+func (mock *SaramaConsumerGroupMock) Resume(topicPartitions map[string][]int32) {
+}
+
+func (mock *SaramaConsumerGroupMock) ResumeAll() {
 }
 
 // Close calls CloseFunc.


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
This is a fix to prevent the following error from occurring, when running unit tests, in other services that use the mock sarama consumer group in dp-kafka:

github.com/!o!n!sdigital/dp-kafka/v3@v3.3.1/mock/sarama_cg.go:15:5: cannot use &SaramaConsumerGroupMock{} (type *SaramaConsumerGroupMock) as type sarama.ConsumerGroup in assignment:
    *SaramaConsumerGroupMock does not implement sarama.ConsumerGroup (missing Pause method)

# How to review
<!--- Describe in detail how you tested your changes. -->
Check the code looks correct.

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
