### PR TITLE
Add support for optional post channel close function

### DIFF
--- a/kafkatest/message_consumer.go
+++ b/kafkatest/message_consumer.go
@@ -74,7 +74,7 @@ func (internal *cgInternal) stopListeningToConsumerFunc(ctx context.Context) err
 	return nil
 }
 
-func (internal *cgInternal) closeFunc(ctx context.Context) error {
+func (internal *cgInternal) closeFunc(ctx context.Context, optFuncs ...kafka.OptFunc) error {
 	select {
 	case <-internal.cgChannels.Closer:
 	default:


### PR DESCRIPTION
### What

This pr implements the support for OptFunc when closing the kafka consumer, which is basically an optional function that is run once the upstream channel is closed and before consumer closer is called. For example , while doing the graceful shutdown you would have received messages which are not processed, like you would have released a message when you receive it from upstream and added to a batch and after a certain time when the batch is processed then only messages are committed back . Now if you don't process this batch during the graceful shutdown this can create a lag in the consumer group. The optional functions can basically do this for you. During the graceful shutdown you can pass, say for the above case the batch processing to process the unprocessed batch and commit them back to the consumer group, while making sure no new messages are received.The optional function is run once the upstream channel is closed to make sure no new messages are received and before the consumer is closed so that the remaining messages can be processed and committed back to the consumer group.

### How to review

Please check if the changes make sense

### Who can review

Anyone except me
