### PR TITLE
Amending health check response code

### DIFF
--- a/health_info.go
+++ b/health_info.go
@@ -53,8 +53,8 @@ func (h *HealthInfoMap) UpdateStatus(state *health.CheckState, minHealthyThresho
 	}
 
 	if numHealthy >= minHealthyThreshold {
-		// Enough brokers are healthy, but not all of them
-		return state.Update(health.StatusWarning, h.errorMsg(), 0)
+		// Enough brokers are healthy, but not all of them.  We should still return OK though as the services should not fail at this point
+		return state.Update(health.StatusOK, h.errorMsg(), 0)
 	}
 
 	// Not enough brokers are healthy

--- a/health_test.go
+++ b/health_test.go
@@ -173,7 +173,7 @@ func TestKafkaProducerHealthcheck(t *testing.T) {
 			Convey("Then Checker sets the health status to 'WARNING' because at least 2 brokers are reachable and valid", func() {
 				err := p.Checker(context.Background(), checkState)
 				So(err, ShouldBeNil)
-				So(checkState.Status(), ShouldEqual, health.StatusWarning)
+				So(checkState.Status(), ShouldEqual, health.StatusOK)
 				So(checkState.Message(), ShouldEqual, "broker(s) not reachable at: [localhost:0000]")
 				So(checkState.StatusCode(), ShouldEqual, 0)
 			})
@@ -185,7 +185,7 @@ func TestKafkaProducerHealthcheck(t *testing.T) {
 			Convey("Then Checker sets the health status to 'WARNING' because at least 2 brokers are reachable and valid", func() {
 				err := p.Checker(context.Background(), checkState)
 				So(err, ShouldBeNil)
-				So(checkState.Status(), ShouldEqual, health.StatusWarning)
+				So(checkState.Status(), ShouldEqual, health.StatusOK)
 				So(checkState.Message(), ShouldEqual, "topic testTopic not available in broker(s): [localhost:12303]")
 				So(checkState.StatusCode(), ShouldEqual, 0)
 			})
@@ -278,7 +278,7 @@ func TestKafkaConsumerHealthcheck(t *testing.T) {
 			Convey("Then Checker sets the health status to 'WARNING' because at least one broker is reachable and valid", func() {
 				err := cg.Checker(context.Background(), checkState)
 				So(err, ShouldBeNil)
-				So(checkState.Status(), ShouldEqual, health.StatusWarning)
+				So(checkState.Status(), ShouldEqual, health.StatusOK)
 				So(checkState.Message(), ShouldEqual, "broker(s) not reachable at: [localhost:0000]")
 				So(checkState.StatusCode(), ShouldEqual, 0)
 			})
@@ -290,7 +290,7 @@ func TestKafkaConsumerHealthcheck(t *testing.T) {
 			Convey("Then Checker sets the health status to 'WARNING' because at least one broker is reachable and valid", func() {
 				err := cg.Checker(context.Background(), checkState)
 				So(err, ShouldBeNil)
-				So(checkState.Status(), ShouldEqual, health.StatusWarning)
+				So(checkState.Status(), ShouldEqual, health.StatusOK)
 				So(checkState.Message(), ShouldEqual, "topic testTopic not available in broker(s): [localhost:12303]")
 				So(checkState.StatusCode(), ShouldEqual, 0)
 			})


### PR DESCRIPTION
### What

Updating the health status code if number of minimum brokers are healthy.  It should return ok as if a warning is returned our services no longer work, as the "warning" status means the service is unhealthy according to our healthcheckers so events stop being produced and consumed.

### How to review

Ensure the tests pass and the changes make sense.

### Who can review

Anyone.
