### PR TITLE
retract v5 (release v5.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Kafka client wrapper using channels to abstract kafka consumers and producers. This library is built on top of [Sarama](https://github.com/IBM/sarama)
 
+## V5 Retraction
+
+Warning: Version 5.0.0 of this library (this major version) has been temporarily retracted due to incompatibiities in
+the `kafkatest` package used for component testing in downstream apps. Please use the latest v4 release instead and if
+you need to make changes to this library please branch from and merge to the
+[v4 branch](https://github.com/ONSdigital/dp-kafka/tree/v4) instead of `main`.
+
 ## Tools
 
 To run some of our tests you will need additional tooling:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/ONSdigital/dp-kafka/v5
 
 go 1.24.0
 
+retract (
+	v5.0.1 // Contains v5 retraction only
+	v5.0.0 // Retracted due to unexpected issues with kafkatest (see README.md)
+)
+
 require (
 	github.com/IBM/sarama v1.46.3
 	github.com/ONSdigital/dp-healthcheck v1.6.4


### PR DESCRIPTION
### What

Retract the recently released v5 version as the latest version due to incompatibilities with the kafkatest package.
This hotfix will be released as v5.0.1 which itself is also retracted meaning `go get github.com/ONSdigital/dp-kafka` will get the latest v4 instead.

### How to review

Ensure the README makes sense and the retraction in `go.mod` is correct.

### Who can review

Anyone